### PR TITLE
implements the diagnostic level and diagnostic base types

### DIFF
--- a/include/lingua/diagnostic/detail/diagnostic_base.hpp
+++ b/include/lingua/diagnostic/detail/diagnostic_base.hpp
@@ -1,0 +1,50 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_DIAGNOSTIC_DETAIL_DIAGNOSTIC_BASE_HPP
+#define LINGUA_DIAGNOSTIC_DETAIL_DIAGNOSTIC_BASE_HPP
+
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace lingua::detail_diagnostic {
+   template<diagnostic_level level_value>
+   class diagnostic_base {
+   public:
+      static inline constexpr auto level = level_value;
+
+      explicit diagnostic_base(source_coordinate_range const coordinates, std::string help_message) noexcept
+         : coordinates_{coordinates}
+         , help_message_{std::move(help_message)}
+      {
+      }
+
+      source_coordinate_range coordinates() const noexcept { return coordinates_; }
+
+      std::string_view help_message() const noexcept { return help_message_; }
+
+   protected:
+      ~diagnostic_base() = default;
+
+   private:
+      source_coordinate_range coordinates_;
+      std::string help_message_;
+   };
+}   // namespace lingua::detail_diagnostic
+
+#endif   // LINGUA_DIAGNOSTIC_DETAIL_DIAGNOSTIC_BASE_HPP

--- a/include/lingua/diagnostic/diagnostic_level.hpp
+++ b/include/lingua/diagnostic/diagnostic_level.hpp
@@ -1,0 +1,23 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEVEL_HPP
+#define LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEVEL_HPP
+
+namespace lingua {
+   enum class diagnostic_level { remark, warning, ill_formed };
+}   // namespace lingua
+
+#endif   // LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEVEL_HPP

--- a/include/lingua/source_coordinate.hpp
+++ b/include/lingua/source_coordinate.hpp
@@ -1,0 +1,188 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_SOURCE_COORDINATE_HPP
+#define LINGUA_SOURCE_COORDINATE_HPP
+
+#include "lingua/utility/contract.hpp"
+#include <cjdb/utility/strong_value.hpp>
+#include <cstdint>
+#include <fmt/format.h>
+#include <tuple>
+
+namespace lingua {
+   class [[nodiscard]] source_coordinate
+   {
+      struct column_tag {
+      };
+      struct line_tag {
+      };
+
+   public:
+      using value_type = std::intmax_t;
+      using column_type = cjdb::strong_value<value_type, column_tag>;
+      using line_type = cjdb::strong_value<value_type, line_tag>;
+
+      /// \brief Initialises the object so that it is equivalent to
+      ///        source_coordinate{line_type{1}, column_type{1}}.
+      ///
+      constexpr source_coordinate() = default;
+
+      /// \brief Initialises the column value with the column parameter and initialises the line
+      ///        value with the line parameter.
+      ///
+      constexpr explicit source_coordinate(line_type const line, column_type const column) noexcept
+         : line_{line}
+         , column_{column}
+      {
+         LINGUA_EXPECTS(line >= line_type{0});
+         LINGUA_EXPECTS(column >= column_type{0});
+      }
+
+      /// \brief Returns the column value.
+      ///
+      constexpr column_type column() const noexcept { return column_; }
+
+      /// \brief Returns the line value.
+      ///
+      constexpr line_type line() const noexcept { return line_; }
+
+      /// \brief Checks that the column and line values of x are the same as the column and line
+      ///        values of y.
+      ///
+      constexpr friend bool operator==(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return std::tie(x.column_, x.line_) == std::tie(y.column_, y.line_);
+      }
+
+      /// \brief Checks that the column and line values of x are not the same as the column and line
+      ///        values of y.
+      ///
+      constexpr friend bool operator!=(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return not(x == y);
+      }
+
+      /// \brief Checks that a source_coordinate is strictly less than another source_coordinate.
+      /// \param x A source_coordinate to be checked.
+      /// \param y A source_coordinate to be checked.
+      /// \returns true if:
+      ///     * `x.line()` is less than `y.line()`
+      ///     * `x.line() == y.line()` and `x.column()` is less than `y.column()`
+      ///  false otherwise
+      ///
+      constexpr friend bool operator<(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return x.line() < y.line() or (x.line() == y.line() and x.column() < y.column());
+      }
+
+      /// \brief Checks that a source_coordinate is strictly greater than another source_coordinate.
+      /// \param x A source_coordinate to be checked.
+      /// \param y A source_coordinate to be checked.
+      /// \returns `y < x`
+      ///
+      constexpr friend bool operator>(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return y < x;
+      }
+
+      /// \brief Checks that a source_coordinate is partially less than another source_coordinate.
+      /// \param x A source_coordinate to be checked.
+      /// \param y A source_coordinate to be checked.
+      /// \returns `not (y < x)`
+      ///
+      constexpr friend bool operator<=(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return not(y < x);
+      }
+
+      /// \brief Checks that a source_coordinate is partially less than another source_coordinate.
+      /// \param x A source_coordinate to be checked.
+      /// \param y A source_coordinate to be checked.
+      /// \returns `not (x < y)`
+      ///
+      constexpr friend bool operator>=(source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return not(x < y);
+      }
+
+      /// \brief Moves x by:
+      ///       1. adding y.line() to x.line(), and
+      ///       2. (a) adding y.column() to x.column() if y.line() == 0, or
+      ///          (b) assigning y.column() to x.column() otherwise
+      ///
+      constexpr friend source_coordinate operator+(
+         source_coordinate const x, source_coordinate const y) noexcept
+      {
+         return source_coordinate{line_type{x.line() + y.line()},
+            column_type{line_type{0} == y.line()
+                           ? x.column() + y.column()
+                           : column_type{0} < y.column() ? y.column() : column_type{1}}};
+      }
+
+   private:
+      line_type line_{1};
+      column_type column_{1};
+   };
+}   // namespace lingua
+
+namespace fmt {
+   template<>
+   struct formatter<lingua::source_coordinate::line_type> {
+      template<class Context>
+      constexpr auto parse(Context& c) noexcept
+      {
+         return c.begin();
+      }
+
+      template<class Context>
+      constexpr auto format(lingua::source_coordinate::line_type const line, Context& c) noexcept
+      {
+         return ::fmt::format_to(c.begin(), "{}", static_cast<std::intmax_t>(line));
+      }
+   };
+
+   template<>
+   struct formatter<lingua::source_coordinate::column_type> {
+      template<class Context>
+      constexpr auto parse(Context& c) noexcept
+      {
+         return c.begin();
+      }
+
+      template<class Context>
+      constexpr auto format(lingua::source_coordinate::column_type const column, Context& c) noexcept
+      {
+         return ::fmt::format_to(c.begin(), "{}", static_cast<std::intmax_t>(column));
+      }
+   };
+
+   template<>
+   struct formatter<lingua::source_coordinate> {
+      template<class Context>
+      constexpr auto parse(Context& c) noexcept
+      {
+         return c.begin();
+      }
+
+      template<class Context>
+      constexpr auto format(lingua::source_coordinate const coordinate, Context& c) noexcept
+      {
+         return ::fmt::format_to(c.begin(), "{}:{}", coordinate.line(), coordinate.column());
+      }
+   };
+}   // namespace fmt
+
+#endif   // LINGUA_SOURCE_COORDINATE_HPP

--- a/include/lingua/source_coordinate_range.hpp
+++ b/include/lingua/source_coordinate_range.hpp
@@ -1,0 +1,107 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_LEXER_SOURCE_COORDINATE_RANGE_HPP
+#define LINGUA_LEXER_SOURCE_COORDINATE_RANGE_HPP
+
+#include "lingua/source_coordinate.hpp"
+#include "lingua/utility/contract.hpp"
+#include <fmt/format.h>
+#include <range/v3/distance.hpp>
+#include <tuple>
+
+namespace lingua {
+   class [[nodiscard]] source_coordinate_range
+   {
+   public:
+      /// \brief Constructs a source_coordinate_range.
+      /// \param begin The beginning of the source_coordinate range.
+      /// \param end The end of the source_coordinate range.
+      /// \note begin and end form the half-open interval [begin, end).
+      ///
+      explicit constexpr source_coordinate_range(
+         source_coordinate const begin, source_coordinate const end) noexcept
+         : begin_{begin}
+         , end_{end}
+      {
+         LINGUA_EXPECTS(begin <= end);
+      }
+
+      /// \brief Returns the beginning of the source_coordinate range.
+      /// \returns the beginning of the source_coordinate range.
+      ///
+      constexpr source_coordinate begin() const noexcept { return begin_; }
+
+      /// \brief Returns the end of the source_coordinate range.
+      /// \returns the end of the source_coordinate range.
+      ///
+      constexpr source_coordinate end() const noexcept { return end_; }
+
+      /// \brief Checks if the range is empty.
+      /// \returns true if `begin() == end()`; false otherwise
+      ///
+      constexpr bool empty() const noexcept { return begin() == end(); }
+
+      /// \brief Checks that two source_coordinate_ranges are equivalent.
+      /// \param x A source_coordinate_range to be checked.
+      /// \param y A source_coordinate_range to be checked.
+      /// \returns true if `x.begin() == y.begin()` and `x.end() == y.end()`; false otherwise.
+      ///
+      friend constexpr bool operator==(
+         source_coordinate_range const& x, source_coordinate_range const& y) noexcept
+      {
+         return std::tie(x.begin_, x.end_) == std::tie(y.begin_, y.end_);
+      }
+
+      /// \brief Checks that two source_coordinate_ranges are not equivalent.
+      /// \param x A source_coordinate_range to be checked.
+      /// \param y A source_coordinate_range to be checked.
+      /// \returns `not (x == y)`
+      ///
+      friend constexpr bool operator!=(
+         source_coordinate_range const& x, source_coordinate_range const& y) noexcept
+      {
+         return not(x == y);
+      }
+
+   protected:
+      constexpr void begin(source_coordinate x) noexcept { begin_ = x; }
+
+      constexpr void end(source_coordinate x) noexcept { end_ = x; }
+
+   private:
+      source_coordinate begin_;
+      source_coordinate end_;
+   };
+}   // namespace lingua
+
+namespace fmt {
+   template<>
+   struct formatter<lingua::source_coordinate_range> {
+      template<class Context>
+      constexpr auto parse(Context& c) noexcept
+      {
+         return c.begin();
+      }
+
+      template<class Context>
+      constexpr auto format(lingua::source_coordinate_range const& r, Context& c) noexcept
+      {
+         return ::fmt::format_to(c.begin(), "from {} to {}", r.begin(), r.end());
+      }
+   };
+}   // namespace fmt
+
+#endif   // LINGUA_LEXER_SOURCE_COORDINATE_RANGE_HPP

--- a/test/include/lingua_test/make_coordinates.hpp
+++ b/test/include/lingua_test/make_coordinates.hpp
@@ -1,0 +1,36 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_UNIT_TEST_MAKE_COORDINATES_HPP
+#define LINGUA_UNIT_TEST_MAKE_COORDINATES_HPP
+
+#include "lingua/source_coordinate.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include <range/v3/distance.hpp>
+#include <string_view>
+
+namespace lingua_test {
+   using namespace lingua;
+
+   constexpr source_coordinate_range make_coordinates(std::string_view const lexeme) noexcept
+   {
+      return source_coordinate_range{
+         source_coordinate{source_coordinate::line_type{1}, source_coordinate::column_type{1}},
+         source_coordinate{source_coordinate::line_type{1},
+            source_coordinate::column_type{ranges::distance(lexeme)}}};
+   }
+}   // namespace lingua_test
+
+#endif   // LINGUA_UNIT_TEST_MAKE_COORDINATES_HPP

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -13,3 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+lingua_add_test(
+   FILENAME source_coordinate.cpp
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt)
+
+lingua_add_test(
+   FILENAME source_coordinate_range.cpp
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt
+      range-v3)

--- a/test/unit/source_coordinate.cpp
+++ b/test/unit/source_coordinate.cpp
@@ -1,0 +1,250 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/source_coordinate.hpp"
+
+#include "cjdb/concepts/core/defaultconstructible.hpp"
+#include "cjdb/concepts/core/integral.hpp"
+#include "cjdb/concepts/core/same.hpp"
+#include "cjdb/concepts/object/regular.hpp"
+#include "cjdb/functional/rangecmp/equal_to.hpp"
+#include <doctest.h>
+#include <fmt/format.h>
+#include <type_traits>
+
+TEST_CASE("checks source_coordinate is implemented correctly")
+{
+   // Tests the source coordinate
+   using lingua::source_coordinate;
+
+   static_assert(not cjdb::Integral<source_coordinate::column_type>);
+   static_assert(not cjdb::Integral<source_coordinate::line_type>);
+   static_assert(not cjdb::Same<source_coordinate::column_type, source_coordinate::line_type>);
+   static_assert(cjdb::Regular<source_coordinate>);
+
+   SUBCASE("checks default constructed source_coordinate")
+   {
+      constexpr auto cursor = source_coordinate{};
+      static_assert(cursor.line() == source_coordinate::line_type{1});
+      static_assert(cursor.column() == source_coordinate::column_type{1});
+   }
+
+   SUBCASE("checks explicitly constructed source_coordinate")
+   {
+      constexpr auto column = 42;
+      constexpr auto line = 35;
+
+      constexpr auto cursor = source_coordinate{
+         source_coordinate::line_type{line}, source_coordinate::column_type{column}};
+      static_assert(cursor.line() == source_coordinate::line_type{line});
+      static_assert(cursor.column() == source_coordinate::column_type{column});
+   }
+
+   SUBCASE("checks source_coordinate models EqualityComparable")
+   {
+      SUBCASE("checks == is an equivalence relation")
+      {
+         constexpr auto x =
+            source_coordinate{source_coordinate::line_type{6}, source_coordinate::column_type{5}};
+
+         static_assert(x == x);
+
+         constexpr auto y = x;
+         static_assert(x == y);
+         static_assert(y == x);
+
+         constexpr auto z = y;
+         static_assert(z == y);
+         static_assert(z == x);
+
+         static_assert(not(x != y));
+      }
+
+      SUBCASE("checks when column and line are different")
+      {
+         constexpr auto first =
+            source_coordinate{source_coordinate::line_type{40}, source_coordinate::column_type{30}};
+
+         constexpr auto second =
+            source_coordinate{source_coordinate::line_type{first.line() * first.line()},
+               source_coordinate::column_type{first.column() * first.column()}};
+
+         static_assert(first.column() != second.column());
+         static_assert(first.line() != second.line());
+         static_assert(first != second);
+         static_assert(second != first);
+      }
+
+      SUBCASE("checks when column same, line different")
+      {
+         constexpr auto column = 30;
+
+         constexpr auto first = source_coordinate{
+            source_coordinate::line_type{column}, source_coordinate::column_type{column}};
+
+         constexpr auto second = source_coordinate{
+            source_coordinate::line_type{column * 2}, source_coordinate::column_type{column}};
+
+         static_assert(first.line() != second.line());
+         static_assert(first.column() == second.column());
+         static_assert(first != second);
+      }
+
+      SUBCASE("checks when column different, line same")
+      {
+         constexpr auto line = 30;
+
+         constexpr auto first = source_coordinate{
+            source_coordinate::line_type{line}, source_coordinate::column_type{line * 4}};
+
+         constexpr auto second = source_coordinate{
+            source_coordinate::line_type{line}, source_coordinate::column_type{line}};
+
+         static_assert(first.column() != second.column());
+         static_assert(first.line() == second.line());
+         static_assert(first != second);
+      }
+   }
+
+   SUBCASE("checks source_coordinate models StrictTotallyOrdered")
+   {
+      SUBCASE("checks < is imposes a total order")
+      {
+         SUBCASE("checks when line1 < line2")
+         {
+            constexpr auto first =
+               source_coordinate{source_coordinate::line_type{4}, source_coordinate::column_type{75}};
+            constexpr auto second =
+               source_coordinate{source_coordinate::line_type{6}, source_coordinate::column_type{32}};
+
+            static_assert(first.line() < second.line());
+            static_assert(first.column() > second.column());
+
+            static_assert(first < second);
+            static_assert(second > first);
+            static_assert(first <= second);
+            static_assert(second >= first);
+         }
+
+         SUBCASE("checks when line1 == line2 and column1 < column2")
+         {
+            constexpr auto line = 40;
+            constexpr auto first = source_coordinate{
+               source_coordinate::line_type{line}, source_coordinate::column_type{31}};
+
+            constexpr auto second = source_coordinate{
+               source_coordinate::line_type{line}, source_coordinate::column_type{87}};
+
+            static_assert(first.line() == second.line());
+            static_assert(first.column() < second.column());
+
+            static_assert(first < second);
+            static_assert(second > first);
+            static_assert(first <= second);
+            static_assert(second >= first);
+         }
+
+         SUBCASE("checks when coordinate1 == coordinate2")
+         {
+            constexpr auto first = source_coordinate{
+               source_coordinate::line_type{42}, source_coordinate::column_type{32}};
+            constexpr auto second = first;
+
+            static_assert(first == second);
+            static_assert(first <= second);
+            static_assert(second >= first);
+         }
+      }
+   }
+
+   SUBCASE("Check source_coordinate motion is correct")
+   {
+      constexpr auto xcol = 5;
+      constexpr auto xline = 32;
+      constexpr auto x =
+         source_coordinate{source_coordinate::line_type{xline}, source_coordinate::column_type{xcol}};
+
+      SUBCASE("When y.column() == 0")
+      {
+         constexpr auto ycol = 0;
+         constexpr auto yline = 76;
+         constexpr auto y = source_coordinate{
+            source_coordinate::line_type{yline}, source_coordinate::column_type{ycol}};
+
+         static_assert(x != y);
+         static_assert(y.column() == source_coordinate::column_type{0});
+
+         constexpr auto result = x + y;
+         constexpr auto expected = source_coordinate{
+            source_coordinate::line_type{xline + yline}, source_coordinate::column_type{1}};
+         static_assert(result == expected);
+      }
+
+      SUBCASE("When y.line() == 0")
+      {
+         constexpr auto ycol = 25;
+         constexpr auto yline = 0;
+         constexpr auto y = source_coordinate{
+            source_coordinate::line_type{yline}, source_coordinate::column_type{ycol}};
+
+         static_assert(x != y);
+         static_assert(y.line() == source_coordinate::line_type{0});
+
+         constexpr auto result = x + y;
+         constexpr auto expected = source_coordinate{
+            source_coordinate::line_type{xline},
+            source_coordinate::column_type{xcol + ycol},
+         };
+         static_assert(result == expected);
+      }
+
+      SUBCASE("When y.column() != 0 and y.line() != 0")
+      {
+         constexpr auto ycol = 32;
+         constexpr auto yline = 23;
+         constexpr auto y = source_coordinate{
+            source_coordinate::line_type{yline}, source_coordinate::column_type{ycol}};
+
+         constexpr auto result = x + y;
+         constexpr auto expected = source_coordinate{
+            source_coordinate::line_type{xline + yline}, source_coordinate::column_type{ycol}};
+         static_assert(result == expected);
+      }
+   }
+
+   SUBCASE("Check ostream operators are correct")
+   {
+      SUBCASE("Check line")
+      {
+         constexpr auto line = source_coordinate::line_type{32};
+         auto const result = fmt::format("{}", line);
+         CHECK(result == "32");
+      }
+      SUBCASE("Check column")
+      {
+         constexpr auto column = source_coordinate::column_type{28};
+         auto const result = fmt::format("{}", column);
+         CHECK(result == "28");
+      }
+      SUBCASE("Check source_coordinate")
+      {
+         constexpr auto cursor =
+            source_coordinate{source_coordinate::line_type{10}, source_coordinate::column_type{4}};
+
+         auto const result = fmt::format("{}", cursor);
+         CHECK(result == "10:4");
+      }
+   }
+}

--- a/test/unit/source_coordinate_range.cpp
+++ b/test/unit/source_coordinate_range.cpp
@@ -1,0 +1,62 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/source_coordinate_range.hpp"
+
+#include "lingua/source_coordinate.hpp"
+#include <doctest.h>
+
+TEST_CASE("checks that source_coordinate_ranges behave correctly")
+{
+   using lingua::source_coordinate;
+   using lingua::source_coordinate_range;
+
+   constexpr auto first1 = source_coordinate{};
+   constexpr auto last1 =
+      source_coordinate{source_coordinate::line_type{15}, source_coordinate::column_type{7}};
+   constexpr auto r1 = source_coordinate_range{first1, last1};
+
+   CHECK(r1.begin() == first1);
+   CHECK(r1.end() == last1);
+
+   CHECK(r1 == r1);
+   CHECK(not(r1 != r1));
+
+   // check an empty range
+   constexpr auto first2 =
+      source_coordinate{source_coordinate::line_type{4}, source_coordinate::column_type{18}};
+   constexpr auto r2 = source_coordinate_range{first2, first2};
+   CHECK(r2.begin() == first2);
+   CHECK(r2.end() == first2);
+   CHECK(r2.empty());
+
+   // check operator!= is symmetric
+   CHECK(r2 != r1);
+   CHECK(r1 != r2);
+
+   // check operator== complements operator!=
+   CHECK(not(r2 == r1));
+   CHECK(not(r1 == r2));
+
+   // check operator== and operator!= are transitive
+   constexpr auto r3 = source_coordinate_range{first1, last1};
+   REQUIRE(r1 == r3);
+   REQUIRE(r3 != r2);
+
+   constexpr auto r4 = r3;
+   REQUIRE(r3 == r4);
+   CHECK(r1 == r4);
+   CHECK(r2 != r4);
+}


### PR DESCRIPTION
Closes #3

From the design specification:

>    All diagnostics should store a range of coordinates to source
>    tokens, and a help message. There will be three diagnostic types:
>    ill-formed, warning, and remark.

Since the underlying implementation of one diagnostic is the same as
another, it makes sense to have a common base for every diagnostic, to:

1. implement [DRY]
2. take advantage of [EBO]

The base class will rely on a diagnostic level type, so it makes sense
to couple it in #3.

Diagnostics are intended to be privately derived from the diagnostic
base, although the implementation has no way to make this guarantee.