### PR TITLE
creates diagnostic for unrecognised escapes (closes #5)

### DIFF
--- a/include/lingua/diagnostic/lexical/unknown_escape.hpp
+++ b/include/lingua/diagnostic/lexical/unknown_escape.hpp
@@ -1,0 +1,136 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_DIAGNOSTIC_DIAGNOSTIC_BAD_ESCAPE_HPP
+#define LINGUA_DIAGNOSTIC_DIAGNOSTIC_BAD_ESCAPE_HPP
+
+#include "lingua/diagnostic/detail/diagnostic_base.hpp"
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/lexer/is_escape.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include "lingua/utility/contract.hpp"
+#include <cassert>
+#include <fmt/format.h>
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/distance.hpp>
+#include <range/v3/size.hpp>
+#include <range/v3/to_container.hpp>
+#include <range/v3/view/repeat_n.hpp>
+#include <range/v3/view/subrange.hpp>
+#include <string_view>
+
+namespace lingua {
+   namespace detail_unknown_escape {
+      enum class unknown_escape_kind { ascii, byte, unicode };
+      using ranges::begin, ranges::end, ranges::distance;
+
+      template<unknown_escape_kind kind>
+      class unknown_escape_impl
+      : private detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed> {
+         using base_t = detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed>;
+         using string_view = std::string_view;
+
+      public:
+         using base_t::coordinates;
+         using base_t::help_message;
+         using base_t::level;
+
+         explicit unknown_escape_impl(string_view const lexeme,
+            ranges::subrange<string_view::iterator> const escape,
+            source_coordinate_range const coordinates) noexcept
+            : base_t{
+               coordinates,
+               format_diagnostic(
+                  (LINGUA_EXPECTS(distance(lexeme) >= 4),
+                   lexeme),
+                  (LINGUA_EXPECTS(distance(escape) >= 2),
+                   LINGUA_EXPECTS(*begin(escape) == '\\'),
+                   string_view{begin(escape), static_cast<string_view::size_type>(distance(escape))}))
+            }
+         {
+            auto const data = string_view{
+               begin(escape),
+               static_cast<string_view::size_type>(distance(escape))
+            };
+            if constexpr (kind == unknown_escape_kind::ascii) {
+               LINGUA_EXPECTS(not lingua::is_ascii_escape(data));
+            }
+            else if constexpr (kind == unknown_escape_kind::byte) {
+               LINGUA_EXPECTS(not lingua::is_byte_escape(data));
+            }
+            else {
+               LINGUA_EXPECTS(not lingua::is_unicode_escape(data));
+            }
+         }
+
+      private:
+         static std::string
+         format_diagnostic(string_view const lexeme, string_view const unrecognised_escape) noexcept
+         {
+            using namespace ranges;
+
+            auto top_line = fmt::format("unrecognised {} escape '{}' in string literal `", kind,
+               unrecognised_escape);
+            auto escape_highlight = '^' + std::string(size(unrecognised_escape) - 1, '~');
+            // there might be multiple bad escapes in a single string, so we might need some space
+            // padding between the first occurrence and where we're actually reporting
+            auto const padding_size =
+                 static_cast<std::size_t>(distance(begin(lexeme), begin(unrecognised_escape)))
+               + size(top_line);
+            auto padding = std::string(padding_size, ' ');
+            auto bottom_line = fmt::format("{}{}", std::move(padding), std::move(escape_highlight));
+            return fmt::format("{}{}`\n{}", std::move(top_line), lexeme, std::move(bottom_line));
+         }
+      };
+   } // namespace detail_unknown_escape
+
+   using unknown_escape_ascii =
+      detail_unknown_escape::unknown_escape_impl<detail_unknown_escape::unknown_escape_kind::ascii>;
+   using unknown_escape_byte =
+      detail_unknown_escape::unknown_escape_impl<detail_unknown_escape::unknown_escape_kind::byte>;
+   using unknown_escape_unicode =
+      detail_unknown_escape::unknown_escape_impl<detail_unknown_escape::unknown_escape_kind::unicode>;
+} // namespace lingua
+
+namespace fmt {
+   template<>
+   struct formatter<lingua::detail_unknown_escape::unknown_escape_kind> {
+      template<class Context>
+      constexpr auto parse(Context& c) noexcept
+      {
+         return c.begin();
+      }
+
+      template<class Context>
+      constexpr auto
+      format(lingua::detail_unknown_escape::unknown_escape_kind const kind, Context& c) noexcept
+      {
+         switch (kind) {
+         case lingua::detail_unknown_escape::unknown_escape_kind::ascii:
+            return ::fmt::format_to(c.begin(), "ASCII");
+         case lingua::detail_unknown_escape::unknown_escape_kind::byte:
+            return ::fmt::format_to(c.begin(), "byte");
+         case lingua::detail_unknown_escape::unknown_escape_kind::unicode:
+            return ::fmt::format_to(c.begin(), "Unicode");
+         default:
+            LINGUA_ASSERT(false and "internal compiler error: uknown kind of unkonw_escape_kind");
+            std::abort();
+         }
+      }
+   };
+} // namespace fmt
+
+#endif // LINGUA_DIAGNOSTIC_DIAGNOSTIC_BAD_ESCAPE_HPP

--- a/include/lingua/lexer/is_escape.hpp
+++ b/include/lingua/lexer/is_escape.hpp
@@ -1,0 +1,27 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_LEXER_IS_ESCAPE_HPP
+#define LINGUA_LEXER_IS_ESCAPE_HPP
+
+#include <string_view>
+
+namespace lingua {
+   bool is_ascii_escape(std::string_view const escape) noexcept;
+   bool is_byte_escape(std::string_view const escape) noexcept;
+   bool is_unicode_escape(std::string_view const escape) noexcept;
+} // namespace lingua
+
+#endif // LINGUA_LEXER_IS_ESCAPE_HPP

--- a/source/lexer/CMakeLists.txt
+++ b/source/lexer/CMakeLists.txt
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(lexer)
+lingua_add_library(FILENAME is_escape.cpp
+                   LIBRARY_TYPE OBJECT
+                   LIBRARIES cjdb fmt::fmt range-v3)

--- a/source/lexer/is_escape.cpp
+++ b/source/lexer/is_escape.cpp
@@ -1,0 +1,78 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/lexer/is_escape.hpp"
+#include "lingua/utility/contract.hpp"
+#include <cjdb/cctype/isdigit.hpp>
+#include <cjdb/cctype/isxdigit.hpp>
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/begin_end.hpp>
+#include <range/v3/distance.hpp>
+#include <range/v3/iterator/operations.hpp>
+#include <range/v3/view.hpp>
+#include <string_view>
+#include <unordered_set>
+
+namespace lingua {
+   using ranges::distance;
+   using std::string_view;
+
+   bool is_ascii_escape(string_view const escape) noexcept
+   {
+      LINGUA_EXPECTS(distance(escape) == 2 or distance(escape) == 4);
+      LINGUA_EXPECTS(escape[0] == '\\');
+      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == 'x' : true);
+
+      if (distance(escape) == 2) {
+         static auto const valid_escapes = std::unordered_set<char>{'n', 'r', 't', '\\', '0'};
+         return valid_escapes.find(escape.back()) != end(valid_escapes);
+      }
+
+      auto const leading = escape[2];
+      return cjdb::isdigit(leading) and leading <= '7' and cjdb::isxdigit(escape.back());
+   }
+
+   bool is_byte_escape(string_view const escape) noexcept
+   {
+      LINGUA_EXPECTS(distance(escape) == 2 or distance(escape) == 4);
+      LINGUA_EXPECTS(escape[0] == '\\');
+      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == 'x' : true);
+
+      return distance(escape) == 2 ? is_ascii_escape(escape)
+                                   : cjdb::isxdigit(escape[2]) and cjdb::isxdigit(escape[3]);
+   }
+
+   using namespace std::string_view_literals;
+   constexpr auto unicode_escape_prefix = R"(\u{)"sv;
+   constexpr auto unicode_escape_suffix = '}';
+
+   bool is_unicode_escape(string_view const escape) noexcept
+   {
+      LINGUA_EXPECTS(distance(escape) > 4);
+      LINGUA_EXPECTS(escape.starts_with(unicode_escape_prefix));
+      LINGUA_EXPECTS(escape.ends_with(unicode_escape_suffix));
+      LINGUA_EXPECTS(ranges::count(escape, unicode_escape_suffix) == 1);
+
+      using ranges::all_of, ranges::find;
+      using ranges::end, ranges::next, ranges::prev;
+      namespace view = ranges::view;
+
+      auto not_suffix = [](auto const c) noexcept { return c != unicode_escape_suffix; };
+      auto unicode = escape | view::drop(3) | view::take_while(not_suffix);
+      return distance(unicode) <= 6 and all_of(unicode, cjdb::isxdigit);
+   }
+} // namespace lingua

--- a/test/include/lingua_test/make_coordinates.hpp
+++ b/test/include/lingua_test/make_coordinates.hpp
@@ -27,10 +27,16 @@ namespace lingua_test {
    constexpr source_coordinate_range make_coordinates(std::string_view const lexeme) noexcept
    {
       return source_coordinate_range{
-         source_coordinate{source_coordinate::line_type{1}, source_coordinate::column_type{1}},
-         source_coordinate{source_coordinate::line_type{1},
-            source_coordinate::column_type{ranges::distance(lexeme)}}};
+         source_coordinate{
+            source_coordinate::line_type{1},
+            source_coordinate::column_type{1}
+         },
+         source_coordinate{
+            source_coordinate::line_type{1},
+            source_coordinate::column_type{ranges::distance(lexeme)}
+         }
+      };
    }
-}   // namespace lingua_test
+} // namespace lingua_test
 
-#endif   // LINGUA_UNIT_TEST_MAKE_COORDINATES_HPP
+#endif // LINGUA_UNIT_TEST_MAKE_COORDINATES_HPP

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -32,3 +32,6 @@ lingua_add_test(
       doctest::doctest
       fmt::fmt
       range-v3)
+
+add_subdirectory(diagnostic)
+add_subdirectory(lexer)

--- a/test/unit/diagnostic/CMakeLists.txt
+++ b/test/unit/diagnostic/CMakeLists.txt
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(lexer)
+add_subdirectory(lexical)

--- a/test/unit/diagnostic/lexical/CMakeLists.txt
+++ b/test/unit/diagnostic/lexical/CMakeLists.txt
@@ -13,4 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(lexer)
+lingua_add_test(
+   FILENAME unknown_escape.cpp
+   INCLUDE "${CMAKE_SOURCE_DIR}/test/include"
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt
+      range-v3
+      source.lexer.is_escape)

--- a/test/unit/diagnostic/lexical/unknown_escape.cpp
+++ b/test/unit/diagnostic/lexical/unknown_escape.cpp
@@ -1,0 +1,191 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/diagnostic/lexical/unknown_escape.hpp"
+
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include "lingua_test/make_coordinates.hpp"
+#include <doctest.h>
+#include <functional>
+#include <range/v3/algorithm/adjacent_find.hpp>
+#include <range/v3/distance.hpp>
+#include <string_view>
+
+TEST_CASE("checks unknown ASCII escapes")
+{
+   using lingua::unknown_escape_ascii;
+   using namespace std::string_view_literals;
+
+   constexpr auto ill_formed_string = R"(this\nwas\ra\mista\5e\xef)"sv;
+   constexpr auto find_unknown_escape = [](auto const escape) constexpr noexcept {
+      return [escape](auto const x, auto const y) constexpr noexcept {
+         return x == '\\' and y == escape;
+      };
+   };
+
+   constexpr auto coordinates = lingua_test::make_coordinates(ill_formed_string);
+
+   SUBCASE("invalid letter") {
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('m'));
+      auto const diagnostic = unknown_escape_ascii{
+         ill_formed_string,
+         {first, ranges::next(first, 2)},
+         coordinates
+      };
+
+      CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+      CHECK(diagnostic.coordinates() == coordinates);
+
+      constexpr auto expected_help_message =
+         R"(unrecognised ASCII escape '\m' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
+         "                                                              ^~"sv;
+      CHECK(diagnostic.help_message() == expected_help_message);
+   }
+
+   SUBCASE("invalid digit") {
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('5'));
+      auto const diagnostic = unknown_escape_ascii{
+         ill_formed_string,
+         {first, ranges::next(first, 2)},
+         coordinates
+      };
+
+      CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+      CHECK(diagnostic.coordinates() == coordinates);
+
+      constexpr auto expected_help_message =
+         R"(unrecognised ASCII escape '\5' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
+         "                                                                    ^~"sv;
+      CHECK(diagnostic.help_message() == expected_help_message);
+   }
+
+   SUBCASE("invalid ASCII code") {
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('x'));
+      auto const diagnostic = unknown_escape_ascii{
+         ill_formed_string,
+         {first, ranges::next(first, 4)},
+         coordinates
+      };
+
+      CHECK(diagnostic.coordinates() == coordinates);
+
+      constexpr auto expected_help_message =
+         R"(unrecognised ASCII escape '\xef' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
+         "                                                                         ^~~~"sv;
+      CHECK(diagnostic.help_message() == expected_help_message);
+   }
+}
+
+TEST_CASE("checks unknown byte escapes") {
+   using lingua::unknown_escape_byte;
+   using namespace std::string_view_literals;
+
+   constexpr auto ill_formed_string = R"(this\nwas\ra\mista\5e\xef)"sv;
+   constexpr auto find_unknown_escape = [](auto const escape) constexpr noexcept {
+      return [escape](auto const x, auto const y) constexpr noexcept {
+         return x == '\\' and y == escape;
+      };
+   };
+
+   constexpr auto coordinates = lingua_test::make_coordinates(ill_formed_string);
+
+   SUBCASE("invalid letter") {
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('m'));
+      auto const diagnostic = unknown_escape_byte{
+         ill_formed_string,
+         {first, ranges::next(first, 2)},
+         coordinates
+      };
+
+      CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+      CHECK(diagnostic.coordinates() == coordinates);
+
+      constexpr auto expected_help_message =
+         R"(unrecognised byte escape '\m' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
+         "                                                             ^~"sv;
+      CHECK(diagnostic.help_message() == expected_help_message);
+   }
+
+   SUBCASE("invalid digit") {
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('5'));
+      auto const diagnostic = unknown_escape_byte{
+         ill_formed_string,
+         {first, ranges::next(first, 2)},
+         coordinates
+      };
+
+      CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+      CHECK(diagnostic.coordinates() == coordinates);
+
+      constexpr auto expected_help_message =
+         R"(unrecognised byte escape '\5' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
+         "                                                                   ^~"sv;
+      CHECK(diagnostic.help_message() == expected_help_message);
+   }
+}
+
+void check_diagnostic(std::string_view const ill_formed_string, std::string_view const bad_escape,
+   std::string_view const expected_help_message) noexcept
+{
+   auto const coordinates = lingua_test::make_coordinates(ill_formed_string);
+   using ranges::begin, ranges::end;
+   auto const searcher = std::boyer_moore_horspool_searcher{
+      begin(bad_escape),
+      end(bad_escape)
+   };
+
+   auto const first = std::search(begin(ill_formed_string), end(ill_formed_string), searcher);
+   REQUIRE(first != end(ill_formed_string));
+
+   using lingua::unknown_escape_unicode;
+   auto const diagnostic = unknown_escape_unicode{
+      ill_formed_string,
+      {first, ranges::next(first, ranges::distance(bad_escape))},
+      coordinates
+   };
+
+   CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+   CHECK(diagnostic.coordinates() == coordinates);
+   CHECK(diagnostic.help_message() == expected_help_message);
+}
+
+TEST_CASE("checks unknown Unicode escapes") {
+   using namespace std::string_view_literals;
+   constexpr auto ill_formed_string = R"(this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d})"sv;
+
+   SUBCASE("\\u{5tr1ng}") {
+      constexpr auto bad_escape = "\\u{5tr1ng}"sv;
+      constexpr auto expected_help_message =
+         R"(unrecognised Unicode escape '\u{5tr1ng}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
+         "                                                                 ^~~~~~~~~~"sv;
+      check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
+   }
+
+   SUBCASE("\\u{ill}") {
+      constexpr auto bad_escape = "\\u{ill}"sv;
+      constexpr auto expected_help_message =
+         R"(unrecognised Unicode escape '\u{ill}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
+         "                                                                                       ^~~~~~~"sv;
+      check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
+   }
+   SUBCASE("\\u{f0rM3d}") {
+      constexpr auto bad_escape = "\\u{f0rM3d}"sv;
+      constexpr auto expected_help_message =
+         R"(unrecognised Unicode escape '\u{f0rM3d}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
+         "                                                                                                  ^~~~~~~~~~"sv;
+      check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
+   }
+}

--- a/test/unit/lexer/CMakeLists.txt
+++ b/test/unit/lexer/CMakeLists.txt
@@ -13,4 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-add_subdirectory(lexer)
+lingua_add_test(
+   FILENAME is_escape.cpp
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt
+      range-v3
+      source.lexer.is_escape)

--- a/test/unit/lexer/is_escape.cpp
+++ b/test/unit/lexer/is_escape.cpp
@@ -1,0 +1,356 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/lexer/is_escape.hpp"
+
+#include <cjdb/cctype/isxdigit.hpp>
+#include <cjdb/cctype/toupper.hpp>
+#include <doctest.h>
+#include <fmt/format.h>
+#include <limits>
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/algorithm/none_of.hpp>
+#include <range/v3/view/cartesian_product.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/transform.hpp>
+
+#define LINGUA_CHECK_COMMON(IS_VALID_ESCAPE, ESCAPE_MAX) {                                              \
+      CHECK(IS_VALID_ESCAPE(R"(\n)"));                                                                  \
+      CHECK(IS_VALID_ESCAPE(R"(\r)"));                                                                  \
+      CHECK(IS_VALID_ESCAPE(R"(\t)"));                                                                  \
+      CHECK(IS_VALID_ESCAPE(R"(\\)"));                                                                  \
+      CHECK(IS_VALID_ESCAPE(R"(\0)"));                                                                  \
+                                                                                                        \
+      namespace view = ranges::view;                                                                    \
+      for (auto i : view::iota(0, ESCAPE_MAX)) {                                                        \
+         auto const escape = fmt::format(R"(\x{:02x})", i);                                             \
+         CHECK(IS_VALID_ESCAPE(escape));                                                                \
+      }                                                                                                 \
+                                                                                                        \
+      using namespace std::string_view_literals;                                                        \
+      auto not_ascii_escape = [escapes = "nrtx\\0"sv](auto const c) noexcept {                          \
+         return escapes.find(c) == std::string_view::npos;                                              \
+      };                                                                                                \
+      auto non_escapes = view::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()) \
+                       | view::filter(not_ascii_escape);                                                \
+      for (auto const c : non_escapes) {                                                                \
+         auto const non_escape = fmt::format(R"(\{})", c);                                              \
+         CHECK(not IS_VALID_ESCAPE(non_escape));                                                        \
+      }                                                                                                 \
+   }
+
+TEST_CASE("checks ASCII escapes are valid")
+{
+   LINGUA_CHECK_COMMON(lingua::is_ascii_escape, 128);
+}
+
+TEST_CASE("checks byte escapes are valid")
+{
+   LINGUA_CHECK_COMMON(lingua::is_byte_escape, 256);
+}
+
+#undef LINGUA_CHECK_COMMON
+
+template<int N>
+class generate_strings {
+public:
+   auto operator()() const noexcept
+   { return impl(); }
+
+private:
+   template<class... X>
+   static auto impl(X&&... xs)
+   {
+      namespace view = ranges::view;
+      if constexpr (sizeof...(xs) < N) {
+         auto to_char = [](auto const c) noexcept { return static_cast<char>(c); };
+         auto const printable_ascii = view::iota(static_cast<int>(' '), '~' + 1)
+                                    | view::transform(to_char);
+         return impl(std::forward<X>(xs)..., printable_ascii);
+      }
+      else {
+         auto make_string = []<class... Ts>(std::tuple<Ts...> const& x) noexcept {
+            return fill_result(std::string(sizeof...(Ts), 'z'), x,
+               std::make_index_sequence<sizeof...(Ts)>{});
+         };
+         return view::cartesian_product(std::forward<X>(xs)...) | view::transform(make_string);
+      }
+   }
+
+   template<class... Ts, std::size_t... Size>
+   static std::string
+   fill_result(std::string result, std::tuple<Ts...> const& x, std::index_sequence<Size...>) noexcept
+   {
+      (..., (result[Size] = std::get<Size>(x)));
+      return result;
+   }
+};
+
+#define EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(LENGTH) {                                      \
+   using lingua::is_unicode_escape;                                                       \
+   namespace view = ranges::view;                                                         \
+                                                                                          \
+   auto all_hex = [](std::string_view const x) noexcept {                                 \
+      return ranges::all_of(x, cjdb::isxdigit);                                           \
+   };                                                                                     \
+   auto format = view::transform([](auto&& x) noexcept {                                  \
+      return fmt::format(R"(\u{{{}}})", std::forward<decltype(x)>(x));                    \
+   });                                                                                    \
+   auto no_close_braces = view::filter([](std::string_view const x) noexcept {            \
+      return x.find('}') == std::string_view::npos;                                       \
+   });                                                                                    \
+                                                                                          \
+   auto strings = ::generate_strings<LENGTH>{}() | no_close_braces;                       \
+   SUBCASE("valid escapes") {                                                             \
+      auto expected_escapes = strings | view::filter(all_hex) | format;                   \
+      CHECK(ranges::all_of(expected_escapes, is_unicode_escape));                         \
+   }                                                                                      \
+   SUBCASE("invalid escapes") {                                                           \
+      auto expected_non_escapes = strings | view::filter(std::not_fn(all_hex)) | format;  \
+      CHECK(ranges::none_of(expected_non_escapes, is_unicode_escape));                    \
+   }                                                                                      \
+}                                                                                         \
+
+
+TEST_CASE("checks Unicode escapes are valid")
+{
+   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(1);
+   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(2);
+   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(3);
+
+   SUBCASE("valid escapes") {
+      using lingua::is_unicode_escape;
+
+      SUBCASE("four digits") {
+         CHECK(is_unicode_escape("\\u{0000}"));
+         CHECK(is_unicode_escape("\\u{0001}"));
+         CHECK(is_unicode_escape("\\u{0002}"));
+         CHECK(is_unicode_escape("\\u{0003}"));
+         CHECK(is_unicode_escape("\\u{0004}"));
+         CHECK(is_unicode_escape("\\u{0005}"));
+         CHECK(is_unicode_escape("\\u{0006}"));
+         CHECK(is_unicode_escape("\\u{0007}"));
+         CHECK(is_unicode_escape("\\u{0008}"));
+         CHECK(is_unicode_escape("\\u{0009}"));
+         CHECK(is_unicode_escape("\\u{000a}"));
+         CHECK(is_unicode_escape("\\u{000b}"));
+         CHECK(is_unicode_escape("\\u{000c}"));
+         CHECK(is_unicode_escape("\\u{000d}"));
+         CHECK(is_unicode_escape("\\u{000e}"));
+         CHECK(is_unicode_escape("\\u{000f}"));
+         CHECK(is_unicode_escape("\\u{000A}"));
+         CHECK(is_unicode_escape("\\u{000B}"));
+         CHECK(is_unicode_escape("\\u{000C}"));
+         CHECK(is_unicode_escape("\\u{000D}"));
+         CHECK(is_unicode_escape("\\u{000E}"));
+         CHECK(is_unicode_escape("\\u{000F}"));
+         CHECK(is_unicode_escape("\\u{2345}"));
+         CHECK(is_unicode_escape("\\u{00D5}"));
+         CHECK(is_unicode_escape("\\u{eeF1}"));
+      }
+
+      SUBCASE("five digits") {
+         CHECK(is_unicode_escape("\\u{00000}"));
+         CHECK(is_unicode_escape("\\u{00001}"));
+         CHECK(is_unicode_escape("\\u{00002}"));
+         CHECK(is_unicode_escape("\\u{00003}"));
+         CHECK(is_unicode_escape("\\u{00004}"));
+         CHECK(is_unicode_escape("\\u{00005}"));
+         CHECK(is_unicode_escape("\\u{00006}"));
+         CHECK(is_unicode_escape("\\u{00007}"));
+         CHECK(is_unicode_escape("\\u{00008}"));
+         CHECK(is_unicode_escape("\\u{00009}"));
+         CHECK(is_unicode_escape("\\u{0000a}"));
+         CHECK(is_unicode_escape("\\u{0000b}"));
+         CHECK(is_unicode_escape("\\u{0000c}"));
+         CHECK(is_unicode_escape("\\u{0000d}"));
+         CHECK(is_unicode_escape("\\u{0000e}"));
+         CHECK(is_unicode_escape("\\u{0000f}"));
+         CHECK(is_unicode_escape("\\u{0000A}"));
+         CHECK(is_unicode_escape("\\u{0000B}"));
+         CHECK(is_unicode_escape("\\u{0000C}"));
+         CHECK(is_unicode_escape("\\u{0000D}"));
+         CHECK(is_unicode_escape("\\u{0000E}"));
+         CHECK(is_unicode_escape("\\u{0000F}"));
+         CHECK(is_unicode_escape("\\u{12345}"));
+         CHECK(is_unicode_escape("\\u{F00D5}"));
+         CHECK(is_unicode_escape("\\u{BeeF1}"));
+      }
+
+      SUBCASE("six digits") {
+         CHECK(is_unicode_escape("\\u{000000}"));
+         CHECK(is_unicode_escape("\\u{000001}"));
+         CHECK(is_unicode_escape("\\u{000002}"));
+         CHECK(is_unicode_escape("\\u{000003}"));
+         CHECK(is_unicode_escape("\\u{000040}"));
+         CHECK(is_unicode_escape("\\u{000005}"));
+         CHECK(is_unicode_escape("\\u{000006}"));
+         CHECK(is_unicode_escape("\\u{000007}"));
+         CHECK(is_unicode_escape("\\u{000008}"));
+         CHECK(is_unicode_escape("\\u{000009}"));
+         CHECK(is_unicode_escape("\\u{00000a}"));
+         CHECK(is_unicode_escape("\\u{00000b}"));
+         CHECK(is_unicode_escape("\\u{00000c}"));
+         CHECK(is_unicode_escape("\\u{00000d}"));
+         CHECK(is_unicode_escape("\\u{00000e}"));
+         CHECK(is_unicode_escape("\\u{00000f}"));
+         CHECK(is_unicode_escape("\\u{00000A}"));
+         CHECK(is_unicode_escape("\\u{00000B}"));
+         CHECK(is_unicode_escape("\\u{00000C}"));
+         CHECK(is_unicode_escape("\\u{00000D}"));
+         CHECK(is_unicode_escape("\\u{00000E}"));
+         CHECK(is_unicode_escape("\\u{00000F}"));
+         CHECK(is_unicode_escape("\\u{123045}"));
+         CHECK(is_unicode_escape("\\u{F000D5}"));
+         CHECK(is_unicode_escape("\\u{BeeF10}"));
+      }
+   }
+
+   SUBCASE("invalid escapes") {
+      using lingua::is_unicode_escape;
+      SUBCASE("four digits") {
+         CHECK(not is_unicode_escape("\\u{000G}"));
+         CHECK(not is_unicode_escape("\\u{00H1}"));
+         CHECK(not is_unicode_escape("\\u{0I12}"));
+         CHECK(not is_unicode_escape("\\u{J123}"));
+         CHECK(not is_unicode_escape("\\u{12V4}"));
+         CHECK(not is_unicode_escape("\\u{000L}"));
+         CHECK(not is_unicode_escape("\\u{000M}"));
+         CHECK(not is_unicode_escape("\\u{000N}"));
+         CHECK(not is_unicode_escape("\\u{000O}"));
+         CHECK(not is_unicode_escape("\\u{000P}"));
+         CHECK(not is_unicode_escape("\\u{000Q}"));
+         CHECK(not is_unicode_escape("\\u{000R}"));
+         CHECK(not is_unicode_escape("\\u{000S}"));
+         CHECK(not is_unicode_escape("\\u{000T}"));
+         CHECK(not is_unicode_escape("\\u{000U}"));
+         CHECK(not is_unicode_escape("\\u{000V}"));
+         CHECK(not is_unicode_escape("\\u{000W}"));
+         CHECK(not is_unicode_escape("\\u{000X}"));
+         CHECK(not is_unicode_escape("\\u{addY}"));
+         CHECK(not is_unicode_escape("\\u{000Z}"));
+         CHECK(not is_unicode_escape("\\u{000g}"));
+         CHECK(not is_unicode_escape("\\u{00h1}"));
+         CHECK(not is_unicode_escape("\\u{0i12}"));
+         CHECK(not is_unicode_escape("\\u{j123}"));
+         CHECK(not is_unicode_escape("\\u{&234}"));
+         CHECK(not is_unicode_escape("\\u{000l}"));
+         CHECK(not is_unicode_escape("\\u{000m}"));
+         CHECK(not is_unicode_escape("\\u{000n}"));
+         CHECK(not is_unicode_escape("\\u{000o}"));
+         CHECK(not is_unicode_escape("\\u{000p}"));
+         CHECK(not is_unicode_escape("\\u{000q}"));
+         CHECK(not is_unicode_escape("\\u{000r}"));
+         CHECK(not is_unicode_escape("\\u{000s}"));
+         CHECK(not is_unicode_escape("\\u{000t}"));
+         CHECK(not is_unicode_escape("\\u{000u}"));
+         CHECK(not is_unicode_escape("\\u{000v}"));
+         CHECK(not is_unicode_escape("\\u{000w}"));
+         CHECK(not is_unicode_escape("\\u{000x}"));
+         CHECK(not is_unicode_escape("\\u{addy}"));
+         CHECK(not is_unicode_escape("\\u{000z}"));
+         CHECK(not is_unicode_escape("\\u{<>#^}"));
+      }
+
+      SUBCASE("five digits") {
+         CHECK(not is_unicode_escape("\\u{0000G}"));
+         CHECK(not is_unicode_escape("\\u{000H1}"));
+         CHECK(not is_unicode_escape("\\u{00I12}"));
+         CHECK(not is_unicode_escape("\\u{0J123}"));
+         CHECK(not is_unicode_escape("\\u{K1234}"));
+         CHECK(not is_unicode_escape("\\u{0000L}"));
+         CHECK(not is_unicode_escape("\\u{0000M}"));
+         CHECK(not is_unicode_escape("\\u{0000N}"));
+         CHECK(not is_unicode_escape("\\u{0000O}"));
+         CHECK(not is_unicode_escape("\\u{0000P}"));
+         CHECK(not is_unicode_escape("\\u{0000Q}"));
+         CHECK(not is_unicode_escape("\\u{0000R}"));
+         CHECK(not is_unicode_escape("\\u{0000S}"));
+         CHECK(not is_unicode_escape("\\u{0000T}"));
+         CHECK(not is_unicode_escape("\\u{0000U}"));
+         CHECK(not is_unicode_escape("\\u{0000V}"));
+         CHECK(not is_unicode_escape("\\u{0000W}"));
+         CHECK(not is_unicode_escape("\\u{0000X}"));
+         CHECK(not is_unicode_escape("\\u{baddY}"));
+         CHECK(not is_unicode_escape("\\u{0000Z}"));
+         CHECK(not is_unicode_escape("\\u{0000g}"));
+         CHECK(not is_unicode_escape("\\u{000h1}"));
+         CHECK(not is_unicode_escape("\\u{00i12}"));
+         CHECK(not is_unicode_escape("\\u{0j123}"));
+         CHECK(not is_unicode_escape("\\u{k1&34}"));
+         CHECK(not is_unicode_escape("\\u{0000l}"));
+         CHECK(not is_unicode_escape("\\u{0000m}"));
+         CHECK(not is_unicode_escape("\\u{0000n}"));
+         CHECK(not is_unicode_escape("\\u{0000o}"));
+         CHECK(not is_unicode_escape("\\u{0000p}"));
+         CHECK(not is_unicode_escape("\\u{0000q}"));
+         CHECK(not is_unicode_escape("\\u{0000r}"));
+         CHECK(not is_unicode_escape("\\u{0000s}"));
+         CHECK(not is_unicode_escape("\\u{0000t}"));
+         CHECK(not is_unicode_escape("\\u{0000u}"));
+         CHECK(not is_unicode_escape("\\u{0000v}"));
+         CHECK(not is_unicode_escape("\\u{0000w}"));
+         CHECK(not is_unicode_escape("\\u{0000x}"));
+         CHECK(not is_unicode_escape("\\u{baddy}"));
+         CHECK(not is_unicode_escape("\\u{0000z}"));
+         CHECK(not is_unicode_escape("\\u{$<>#^}"));
+      }
+
+      SUBCASE("six digits") {
+         CHECK(not is_unicode_escape("\\u{00a00G}"));
+         CHECK(not is_unicode_escape("\\u{00a0H1}"));
+         CHECK(not is_unicode_escape("\\u{00aI12}"));
+         CHECK(not is_unicode_escape("\\u{0Ja123}"));
+         CHECK(not is_unicode_escape("\\u{K1a234}"));
+         CHECK(not is_unicode_escape("\\u{00a00L}"));
+         CHECK(not is_unicode_escape("\\u{00a00M}"));
+         CHECK(not is_unicode_escape("\\u{00a00N}"));
+         CHECK(not is_unicode_escape("\\u{00a00O}"));
+         CHECK(not is_unicode_escape("\\u{00a00P}"));
+         CHECK(not is_unicode_escape("\\u{00a00Q}"));
+         CHECK(not is_unicode_escape("\\u{00a00R}"));
+         CHECK(not is_unicode_escape("\\u{00a00S}"));
+         CHECK(not is_unicode_escape("\\u{00a00T}"));
+         CHECK(not is_unicode_escape("\\u{00a00U}"));
+         CHECK(not is_unicode_escape("\\u{00a00V}"));
+         CHECK(not is_unicode_escape("\\u{00a00W}"));
+         CHECK(not is_unicode_escape("\\u{00a00X}"));
+         CHECK(not is_unicode_escape("\\u{baaddY}"));
+         CHECK(not is_unicode_escape("\\u{00a00Z}"));
+         CHECK(not is_unicode_escape("\\u{00a00g}"));
+         CHECK(not is_unicode_escape("\\u{00a0h1}"));
+         CHECK(not is_unicode_escape("\\u{00ai12}"));
+         CHECK(not is_unicode_escape("\\u{0ja123}"));
+         CHECK(not is_unicode_escape("\\u{k1a2&4}"));
+         CHECK(not is_unicode_escape("\\u{00a00l}"));
+         CHECK(not is_unicode_escape("\\u{00a00m}"));
+         CHECK(not is_unicode_escape("\\u{00a00n}"));
+         CHECK(not is_unicode_escape("\\u{00a00o}"));
+         CHECK(not is_unicode_escape("\\u{00a00p}"));
+         CHECK(not is_unicode_escape("\\u{00a00q}"));
+         CHECK(not is_unicode_escape("\\u{00a00r}"));
+         CHECK(not is_unicode_escape("\\u{00a00s}"));
+         CHECK(not is_unicode_escape("\\u{00a00t}"));
+         CHECK(not is_unicode_escape("\\u{00a00u}"));
+         CHECK(not is_unicode_escape("\\u{00a00v}"));
+         CHECK(not is_unicode_escape("\\u{00a00w}"));
+         CHECK(not is_unicode_escape("\\u{00a00x}"));
+         CHECK(not is_unicode_escape("\\u{baaddy}"));
+         CHECK(not is_unicode_escape("\\u{00a00z}"));
+         CHECK(not is_unicode_escape("\\u{$<a>#^}"));
+      }
+   }
+}


### PR DESCRIPTION
* creates utility functions for checking if escapes are valid
* creates diagnostic for unrecognised escapes
* adds tests

clang-format isn't providing a desired style, so it has been disabled
for the near future.