### PR TITLE
adds unknown digit diagnostics (closes #7)

### DIFF
--- a/include/lingua/diagnostic/lexical/unknown_digit.hpp
+++ b/include/lingua/diagnostic/lexical/unknown_digit.hpp
@@ -1,0 +1,111 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_DIAGNOSTIC_LEXICAL_UNKNOWN_DIGIT_HPP
+#define LINGUA_DIAGNOSTIC_LEXICAL_UNKNOWN_DIGIT_HPP
+
+#include "lingua/diagnostic/detail/diagnostic_base.hpp"
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include "lingua/utility/contract.hpp"
+#include "lingua/utility/always_false.hpp"
+#include <fmt/format.h>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/distance.hpp>
+#include <string>
+#include <string_view>
+
+namespace lingua::detail_unknown_digit {
+   enum class kind { binary, octal };
+
+   template<kind k>
+   class unknown_digit_impl
+   : private detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed> {
+      using base_t = detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed>;
+      using string_view = std::string_view;
+
+   public:
+      using base_t::coordinates;
+      using base_t::help_message;
+      using base_t::level;
+
+      explicit unknown_digit_impl(string_view const literal, string_view::iterator const digit,
+         source_coordinate_range const coordinates) noexcept
+         : base_t{coordinates, generate_message(literal, digit)}
+      {
+         LINGUA_EXPECTS(has_correct_prefix(literal));
+         LINGUA_EXPECTS(has_invalid_digit(*digit));
+      }
+   private:
+      static constexpr bool has_correct_prefix(string_view const literal) noexcept
+      {
+         if constexpr (k == kind::binary) {
+            return literal.starts_with("0b");
+         }
+         else if constexpr (k == kind::octal) {
+            return literal.starts_with("0o");
+         }
+      }
+
+      static constexpr bool has_invalid_digit(char const digit) noexcept
+      {
+         if constexpr (k == kind::binary) {
+            return '1' < digit and digit <= '9';
+         }
+         else if constexpr (k == kind::octal) {
+            return digit == '8' or digit == '9';
+         }
+      }
+
+      static std::string
+      generate_message(string_view const literal, string_view::iterator const digit) noexcept
+      {
+         using ranges::distance, ranges::begin;
+         using namespace std::string_view_literals;
+
+         constexpr auto message = "unknown digit `{}` in {} literal `{}`\n"
+                                  "                                  {}"sv;
+         auto arrow = make_arrow(literal, digit);
+         if constexpr (k == kind::binary) {
+            return fmt::format(message, *digit, "binary", literal, arrow);
+         }
+         else if constexpr (k == kind::octal) {
+            return fmt::format(message, *digit, "octal", literal, arrow);
+         }
+         else {
+            static_assert(always_false<>, "unhandled representation for an unknown digit");
+         }
+      }
+
+      static std::string
+      make_arrow(string_view const literal, string_view::iterator const digit) noexcept
+      {
+         using ranges::begin, ranges::distance;
+         using size_type = string_view::size_type;
+         auto const arrow_length = static_cast<size_type>(distance(begin(literal), digit));
+         return std::string(arrow_length, ' ') + '^';
+      }
+   };
+
+   using unknown_digit_binary = unknown_digit_impl<kind::binary>;
+   using unknown_digit_octal = unknown_digit_impl<kind::octal>;
+} // namespace lingua::detail_unknown_digit
+
+namespace lingua {
+   using detail_unknown_digit::unknown_digit_binary;
+   using detail_unknown_digit::unknown_digit_octal;
+} // namespace lingua
+
+#endif // LINGUA_DIAGNOSTIC_LEXICAL_UNKNOWN_DIGIT_HPP

--- a/include/lingua/utility/always_false.hpp
+++ b/include/lingua/utility/always_false.hpp
@@ -1,0 +1,24 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_UTILITY_ALWAYS_FALSE_HPP
+#define LINGUA_UTILITY_ALWAYS_FALSE_HPP
+
+namespace lingua {
+   template<class = void>
+   inline constexpr auto always_false = false;
+} // namespace lingua
+
+#endif // LINGUA_UTILITY_ALWAYS_FALSE_HPP

--- a/test/unit/diagnostic/lexical/CMakeLists.txt
+++ b/test/unit/diagnostic/lexical/CMakeLists.txt
@@ -24,3 +24,14 @@ lingua_add_test(
       fmt::fmt
       range-v3
       source.lexer.is_escape)
+
+lingua_add_test(
+   FILENAME unknown_digit.cpp
+   INCLUDE "${CMAKE_SOURCE_DIR}/test/include"
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt
+      range-v3)

--- a/test/unit/diagnostic/lexical/unknown_digit.cpp
+++ b/test/unit/diagnostic/lexical/unknown_digit.cpp
@@ -1,0 +1,73 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/diagnostic/lexical/unknown_digit.hpp"
+
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua_test/make_coordinates.hpp"
+#include <doctest.h>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/iterator/operations.hpp>
+#include <string_view>
+
+template<class T>
+void check_unknown_digit(std::string_view const kind, std::string_view const literal,
+   std::string_view::iterator const digit, std::string_view const arrow) noexcept
+// [[expects axiom: reachable(literal, digit)]]
+{
+   auto const coordinates = lingua_test::make_coordinates(literal);
+   auto const diagnostic = T{literal, digit, coordinates};
+
+   CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+   CHECK(diagnostic.coordinates() == coordinates);
+
+   auto const expected_help_message = fmt::format("unknown digit `{}` in {} literal `{}`\n"
+                                                  "                                  {}",
+      *digit, kind, literal, arrow);
+   CHECK(expected_help_message == diagnostic.help_message());
+}
+
+TEST_CASE("checks the error type for unknown binary digits") {
+   using lingua::unknown_digit_binary;
+   using namespace std::string_view_literals;
+
+   constexpr auto literal = "0b210_1011_0110_6301_4110_1051_0118"sv;
+   constexpr auto binary = "binary"sv;
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '2'),
+      "  ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '6'),
+      "                ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '3'),
+      "                 ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '4'),
+      "                     ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '5'),
+      "                            ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '8'),
+      "                                  ^");
+}
+
+TEST_CASE("checks the error type for unknown octal digits") {
+   using lingua::unknown_digit_octal;
+   using namespace std::string_view_literals;
+
+   constexpr auto literal = "0o796_950_448"sv;
+   constexpr auto octal = "octal";
+   auto const nine = ranges::find(literal, '9');
+   check_unknown_digit<unknown_digit_octal>(octal, literal, nine, "   ^");
+   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::next(nine, 3), "      ^");
+   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::find(literal, '8'),
+      "            ^");
+}


### PR DESCRIPTION
* adds `unknown_digit_binary` type
* adds `unknown_digit_octal` type
* adds `always_false` variable template for static_asserts that are
  always false
* adds a test case for each type