### PR TITLE
migrates from char to char8_t (closes #11)

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class Lingua(ConanFile):
     requires = ("cjdb/0.1@cjdb/beta",
                 "doctest/2.2.0@bincrafters/stable",
                 "expected/master@cjdb/stable",
-                "fmt/5.3.0@bincrafters/stable",
+                "fmt/head@cjdb/stable",
                 "range-v3/v1.0-beta@cjdb/beta")
     exports_sources = (".clang*", "cmake/*", "CMakeLists.txt", "include/*",
                        "source/*", "test/*", "LICENSE.md")

--- a/include/lingua/diagnostic/detail/diagnostic_base.hpp
+++ b/include/lingua/diagnostic/detail/diagnostic_base.hpp
@@ -29,7 +29,7 @@ namespace lingua::detail_diagnostic {
       static inline constexpr auto level = level_value;
 
       explicit diagnostic_base(source_coordinate_range const coordinates,
-         std::string help_message) noexcept
+         std::u8string help_message) noexcept
          : coordinates_{coordinates}
          , help_message_{std::move(help_message)}
       {}
@@ -37,7 +37,7 @@ namespace lingua::detail_diagnostic {
       source_coordinate_range coordinates() const noexcept
       { return coordinates_; }
 
-      std::string_view help_message() const noexcept
+      std::u8string_view help_message() const noexcept
       { return help_message_; }
 
    protected:
@@ -45,7 +45,7 @@ namespace lingua::detail_diagnostic {
 
    private:
       source_coordinate_range coordinates_;
-      std::string help_message_;
+      std::u8string help_message_;
    };
 } // namespace lingua::detail_diagnostic
 

--- a/include/lingua/diagnostic/lexical/unknown_digit.hpp
+++ b/include/lingua/diagnostic/lexical/unknown_digit.hpp
@@ -34,14 +34,14 @@ namespace lingua::detail_unknown_digit {
    class unknown_digit_impl
    : private detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed> {
       using base_t = detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed>;
-      using string_view = std::string_view;
+      using u8string_view = std::u8string_view;
 
    public:
       using base_t::coordinates;
       using base_t::help_message;
       using base_t::level;
 
-      explicit unknown_digit_impl(string_view const literal, string_view::iterator const digit,
+      explicit unknown_digit_impl(u8string_view const literal, u8string_view::iterator const digit,
          source_coordinate_range const coordinates) noexcept
          : base_t{coordinates, generate_message(literal, digit)}
       {
@@ -49,53 +49,53 @@ namespace lingua::detail_unknown_digit {
          LINGUA_EXPECTS(has_invalid_digit(*digit));
       }
    private:
-      static constexpr bool has_correct_prefix(string_view const literal) noexcept
+      static constexpr bool has_correct_prefix(u8string_view const literal) noexcept
       {
          if constexpr (k == kind::binary) {
-            return literal.starts_with("0b");
+            return literal.starts_with(u8"0b");
          }
          else if constexpr (k == kind::octal) {
-            return literal.starts_with("0o");
+            return literal.starts_with(u8"0o");
          }
       }
 
-      static constexpr bool has_invalid_digit(char const digit) noexcept
+      static constexpr bool has_invalid_digit(char8_t const digit) noexcept
       {
          if constexpr (k == kind::binary) {
-            return '1' < digit and digit <= '9';
+            return u8'1' < digit and digit <= u8'9';
          }
          else if constexpr (k == kind::octal) {
-            return digit == '8' or digit == '9';
+            return digit == u8'8' or digit == u8'9';
          }
       }
 
-      static std::string
-      generate_message(string_view const literal, string_view::iterator const digit) noexcept
+      static std::u8string
+      generate_message(u8string_view const literal, u8string_view::iterator const digit) noexcept
       {
          using ranges::distance, ranges::begin;
          using namespace std::string_view_literals;
 
-         constexpr auto message = "unknown digit `{}` in {} literal `{}`\n"
-                                  "                                  {}"sv;
+         constexpr auto message = u8"unknown digit `{}` in {} literal `{}`\n"
+                                  u8"                                  {}"sv;
          auto arrow = make_arrow(literal, digit);
          if constexpr (k == kind::binary) {
-            return fmt::format(message, *digit, "binary", literal, arrow);
+            return fmt::format(message, *digit, u8"binary", literal, arrow);
          }
          else if constexpr (k == kind::octal) {
-            return fmt::format(message, *digit, "octal", literal, arrow);
+            return fmt::format(message, *digit, u8"octal", literal, arrow);
          }
          else {
-            static_assert(always_false<>, "unhandled representation for an unknown digit");
+            static_assert(always_false<>, u8"unhandled representation for an unknown digit");
          }
       }
 
-      static std::string
-      make_arrow(string_view const literal, string_view::iterator const digit) noexcept
+      static std::u8string
+      make_arrow(u8string_view const literal, u8string_view::iterator const digit) noexcept
       {
          using ranges::begin, ranges::distance;
-         using size_type = string_view::size_type;
+         using size_type = u8string_view::size_type;
          auto const arrow_length = static_cast<size_type>(distance(begin(literal), digit));
-         return std::string(arrow_length, ' ') + '^';
+         return std::u8string(arrow_length, u8' ') + u8'^';
       }
    };
 

--- a/include/lingua/lexer/is_escape.hpp
+++ b/include/lingua/lexer/is_escape.hpp
@@ -19,9 +19,9 @@
 #include <string_view>
 
 namespace lingua {
-   bool is_ascii_escape(std::string_view const escape) noexcept;
-   bool is_byte_escape(std::string_view const escape) noexcept;
-   bool is_unicode_escape(std::string_view const escape) noexcept;
+   bool is_ascii_escape(std::u8string_view const escape) noexcept;
+   bool is_byte_escape(std::u8string_view const escape) noexcept;
+   bool is_unicode_escape(std::u8string_view const escape) noexcept;
 } // namespace lingua
 
 #endif // LINGUA_LEXER_IS_ESCAPE_HPP

--- a/include/lingua/source_coordinate.hpp
+++ b/include/lingua/source_coordinate.hpp
@@ -128,36 +128,37 @@ namespace lingua {
 
 namespace fmt {
    template<>
-   struct formatter<lingua::source_coordinate::line_type> {
-      template<class Context>
-      constexpr auto parse(Context& c) noexcept
+   struct formatter<lingua::source_coordinate::line_type, char8_t> {
+      template<class ParseContext>
+      constexpr auto parse(ParseContext& c) noexcept
       { return c.begin(); }
 
-      template<class Context>
-      constexpr auto format(lingua::source_coordinate::line_type const line, Context& c) noexcept
-      { return ::fmt::format_to(c.begin(), "{}", static_cast<std::intmax_t>(line)); }
+      template<class FormatContext>
+      constexpr auto format(lingua::source_coordinate::line_type const line, FormatContext& c) noexcept
+      { return ::fmt::format_to(c.out(), u8"{}", static_cast<std::intmax_t>(line)); }
    };
 
    template<>
-   struct formatter<lingua::source_coordinate::column_type> {
-      template<class Context>
-      constexpr auto parse(Context& c) noexcept
+   struct formatter<lingua::source_coordinate::column_type, char8_t> {
+      template<class ParseContext>
+      constexpr auto parse(ParseContext& c) noexcept
       { return c.begin(); }
 
-      template<class Context>
-      constexpr auto format(lingua::source_coordinate::column_type const column, Context& c) noexcept
-      { return ::fmt::format_to(c.begin(), "{}", static_cast<std::intmax_t>(column)); }
+      template<class FormatContext>
+      constexpr auto
+      format(lingua::source_coordinate::column_type const column, FormatContext& c) noexcept
+      { return ::fmt::format_to(c.out(), u8"{}", static_cast<std::intmax_t>(column)); }
    };
 
    template<>
-   struct formatter<lingua::source_coordinate> {
-      template<class Context>
-      constexpr auto parse(Context& c) noexcept
+   struct formatter<lingua::source_coordinate, char8_t> {
+      template<class ParseContext>
+      constexpr auto parse(ParseContext& c) noexcept
       { return c.begin(); }
 
-      template<class Context>
-      constexpr auto format(lingua::source_coordinate const coordinate, Context& c) noexcept
-      { return ::fmt::format_to(c.begin(), "{}:{}", coordinate.line(), coordinate.column()); }
+      template<class FormatContext>
+      constexpr auto format(lingua::source_coordinate const coordinate, FormatContext& c) noexcept
+      { return ::fmt::format_to(c.out(), u8"{}:{}", coordinate.line(), coordinate.column()); }
    };
 } // namespace fmt
 

--- a/include/lingua/source_coordinate_range.hpp
+++ b/include/lingua/source_coordinate_range.hpp
@@ -86,14 +86,14 @@ namespace lingua {
 
 namespace fmt {
    template<>
-   struct formatter<lingua::source_coordinate_range> {
-      template<class Context>
-      constexpr auto parse(Context& c) noexcept
+   struct formatter<lingua::source_coordinate_range, char8_t> {
+      template<class ParseContext>
+      constexpr auto parse(ParseContext& c) noexcept
       { return c.begin(); }
 
-      template<class Context>
-      constexpr auto format(lingua::source_coordinate_range const& r, Context& c) noexcept
-      { return ::fmt::format_to(c.begin(), "from {} to {}", r.begin(), r.end()); }
+      template<class FormatContext>
+      constexpr auto format(lingua::source_coordinate_range const& r, FormatContext& c) noexcept
+      { return ::fmt::format_to(c.out(), u8"from {} to {}", r.begin(), r.end()); }
    };
 } // namespace fmt
 

--- a/include/lingua/utility/contract.hpp
+++ b/include/lingua/utility/contract.hpp
@@ -26,23 +26,23 @@
 
 #define LINGUA_ASSERT(...) LINGUA_CONTRACT_IMPL("assertion", __VA_ARGS__)
 
-#define LINGUA_ENSURES(LINGUA_RESULT, ...)                              \
-   LINGUA_CONTRACT_IMPL("post-condition", __VA_ARGS__), LINGUA_RESULT   \
+#define LINGUA_ENSURES(LINGUA_RESULT, ...)                            \
+   LINGUA_CONTRACT_IMPL("post-condition", __VA_ARGS__), LINGUA_RESULT \
 
 
-#define LINGUA_CONTRACT_IMPL(LINGUA_KIND, ...)                             \
-   [](bool const result) constexpr noexcept {                              \
-      if (not result) {                                                    \
-         _Pragma("GCC diagnostic push")                                    \
-            _Pragma("GCC diagnostic ignored \"-Wterminate\"")              \
-            throw std::logic_error{                                        \
-               fmt::format("{} `{}` failed on line {} in file {}",         \
-                  LINGUA_KIND, #__VA_ARGS__, LINGUA_TO_STRING(__LINE__),   \
-                  LINGUA_TO_STRING(__FILE__))                              \
-            };                                                             \
-         _Pragma("GCC diagnostic pop")                                     \
-      }                                                                    \
-   }(static_cast<bool>(__VA_ARGS__))                                       \
+#define LINGUA_CONTRACT_IMPL(LINGUA_KIND, ...)                           \
+   [](bool const result) constexpr noexcept {                            \
+      if (not result) {                                                  \
+         _Pragma("GCC diagnostic push")                                  \
+            _Pragma("GCC diagnostic ignored \"-Wterminate\"")            \
+            throw std::logic_error{                                      \
+               fmt::format("{} `{}` failed on line {} in file {}",       \
+                  LINGUA_KIND, #__VA_ARGS__, LINGUA_TO_STRING(__LINE__), \
+                  LINGUA_TO_STRING(__FILE__))                            \
+            };                                                           \
+         _Pragma("GCC diagnostic pop")                                   \
+      }                                                                  \
+   }(static_cast<bool>(__VA_ARGS__))                                     \
 
 
 

--- a/source/lexer/is_escape.cpp
+++ b/source/lexer/is_escape.cpp
@@ -29,38 +29,38 @@
 
 namespace lingua {
    using ranges::distance;
-   using std::string_view;
+   using std::u8string_view;
 
-   bool is_ascii_escape(string_view const escape) noexcept
+   bool is_ascii_escape(u8string_view const escape) noexcept
    {
       LINGUA_EXPECTS(distance(escape) == 2 or distance(escape) == 4);
-      LINGUA_EXPECTS(escape[0] == '\\');
-      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == 'x' : true);
+      LINGUA_EXPECTS(escape[0] == u8'\\');
+      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == u8'x' : true);
 
       if (distance(escape) == 2) {
-         static auto const valid_escapes = std::unordered_set<char>{'n', 'r', 't', '\\', '0'};
+         static auto const valid_escapes = std::unordered_set{u8'n', u8'r', u8't', u8'\\', u8'0'};
          return valid_escapes.find(escape.back()) != end(valid_escapes);
       }
 
       auto const leading = escape[2];
-      return cjdb::isdigit(leading) and leading <= '7' and cjdb::isxdigit(escape.back());
+      return cjdb::isdigit(leading) and leading <= u8'7' and cjdb::isxdigit(escape.back());
    }
 
-   bool is_byte_escape(string_view const escape) noexcept
+   bool is_byte_escape(u8string_view const escape) noexcept
    {
       LINGUA_EXPECTS(distance(escape) == 2 or distance(escape) == 4);
-      LINGUA_EXPECTS(escape[0] == '\\');
-      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == 'x' : true);
+      LINGUA_EXPECTS(escape[0] == u8'\\');
+      LINGUA_EXPECTS(distance(escape) == 4 ? escape[1] == u8'x' : true);
 
       return distance(escape) == 2 ? is_ascii_escape(escape)
                                    : cjdb::isxdigit(escape[2]) and cjdb::isxdigit(escape[3]);
    }
 
    using namespace std::string_view_literals;
-   constexpr auto unicode_escape_prefix = R"(\u{)"sv;
-   constexpr auto unicode_escape_suffix = '}';
+   constexpr auto unicode_escape_prefix = u8R"(\u{)"sv;
+   constexpr auto unicode_escape_suffix = u8'}';
 
-   bool is_unicode_escape(string_view const escape) noexcept
+   bool is_unicode_escape(u8string_view const escape) noexcept
    {
       LINGUA_EXPECTS(distance(escape) > 4);
       LINGUA_EXPECTS(escape.starts_with(unicode_escape_prefix));

--- a/test/include/lingua_test/make_coordinates.hpp
+++ b/test/include/lingua_test/make_coordinates.hpp
@@ -24,7 +24,7 @@
 namespace lingua_test {
    using namespace lingua;
 
-   constexpr source_coordinate_range make_coordinates(std::string_view const lexeme) noexcept
+   constexpr source_coordinate_range make_coordinates(std::u8string_view const lexeme) noexcept
    {
       return source_coordinate_range{
          source_coordinate{

--- a/test/unit/diagnostic/lexical/unknown_digit.cpp
+++ b/test/unit/diagnostic/lexical/unknown_digit.cpp
@@ -23,8 +23,8 @@
 #include <string_view>
 
 template<class T>
-void check_unknown_digit(std::string_view const kind, std::string_view const literal,
-   std::string_view::iterator const digit, std::string_view const arrow) noexcept
+void check_unknown_digit(std::u8string_view const kind, std::u8string_view const literal,
+   std::u8string_view::iterator const digit, std::u8string_view const arrow) noexcept
 // [[expects axiom: reachable(literal, digit)]]
 {
    auto const coordinates = lingua_test::make_coordinates(literal);
@@ -33,8 +33,8 @@ void check_unknown_digit(std::string_view const kind, std::string_view const lit
    CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
    CHECK(diagnostic.coordinates() == coordinates);
 
-   auto const expected_help_message = fmt::format("unknown digit `{}` in {} literal `{}`\n"
-                                                  "                                  {}",
+   auto const expected_help_message = fmt::format(u8"unknown digit `{}` in {} literal `{}`\n"
+                                                  u8"                                  {}",
       *digit, kind, literal, arrow);
    CHECK(expected_help_message == diagnostic.help_message());
 }
@@ -43,31 +43,31 @@ TEST_CASE("checks the error type for unknown binary digits") {
    using lingua::unknown_digit_binary;
    using namespace std::string_view_literals;
 
-   constexpr auto literal = "0b210_1011_0110_6301_4110_1051_0118"sv;
-   constexpr auto binary = "binary"sv;
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '2'),
-      "  ^");
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '6'),
-      "                ^");
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '3'),
-      "                 ^");
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '4'),
-      "                     ^");
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '5'),
-      "                            ^");
-   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, '8'),
-      "                                  ^");
+   constexpr auto literal = u8"0b210_1011_0110_6301_4110_1051_0118"sv;
+   constexpr auto binary = u8"binary"sv;
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'2'),
+      u8"  ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'6'),
+      u8"                ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'3'),
+      u8"                 ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'4'),
+      u8"                     ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'5'),
+      u8"                            ^");
+   check_unknown_digit<unknown_digit_binary>(binary, literal, ranges::find(literal, u8'8'),
+      u8"                                  ^");
 }
 
 TEST_CASE("checks the error type for unknown octal digits") {
    using lingua::unknown_digit_octal;
    using namespace std::string_view_literals;
 
-   constexpr auto literal = "0o796_950_448"sv;
-   constexpr auto octal = "octal";
-   auto const nine = ranges::find(literal, '9');
-   check_unknown_digit<unknown_digit_octal>(octal, literal, nine, "   ^");
-   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::next(nine, 3), "      ^");
-   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::find(literal, '8'),
-      "            ^");
+   constexpr auto literal = u8"0o796_950_448"sv;
+   constexpr auto octal = u8"octal";
+   auto const nine = ranges::find(literal, u8'9');
+   check_unknown_digit<unknown_digit_octal>(octal, literal, nine, u8"   ^");
+   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::next(nine, 3), u8"      ^");
+   check_unknown_digit<unknown_digit_octal>(octal, literal, ranges::find(literal, u8'8'),
+      u8"            ^");
 }

--- a/test/unit/diagnostic/lexical/unknown_escape.cpp
+++ b/test/unit/diagnostic/lexical/unknown_escape.cpp
@@ -24,22 +24,21 @@
 #include <range/v3/distance.hpp>
 #include <string_view>
 
-TEST_CASE("checks unknown ASCII escapes")
-{
+TEST_CASE("checks unknown ASCII escapes") {
    using lingua::unknown_escape_ascii;
    using namespace std::string_view_literals;
 
-   constexpr auto ill_formed_string = R"(this\nwas\ra\mista\5e\xef)"sv;
+   constexpr auto ill_formed_string = u8R"(this\nwas\ra\mista\5e\xef)"sv;
    constexpr auto find_unknown_escape = [](auto const escape) constexpr noexcept {
       return [escape](auto const x, auto const y) constexpr noexcept {
-         return x == '\\' and y == escape;
+         return x == u8'\\' and y == escape;
       };
    };
 
    constexpr auto coordinates = lingua_test::make_coordinates(ill_formed_string);
 
    SUBCASE("invalid letter") {
-      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('m'));
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape(u8'm'));
       auto const diagnostic = unknown_escape_ascii{
          ill_formed_string,
          {first, ranges::next(first, 2)},
@@ -50,13 +49,13 @@ TEST_CASE("checks unknown ASCII escapes")
       CHECK(diagnostic.coordinates() == coordinates);
 
       constexpr auto expected_help_message =
-         R"(unrecognised ASCII escape '\m' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
-         "                                                              ^~"sv;
+u8R"(unrecognised ASCII escape '\m' in string literal `this\nwas\ra\mista\5e\xef`
+                                                              ^~)"sv;
       CHECK(diagnostic.help_message() == expected_help_message);
    }
 
    SUBCASE("invalid digit") {
-      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('5'));
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape(u8'5'));
       auto const diagnostic = unknown_escape_ascii{
          ill_formed_string,
          {first, ranges::next(first, 2)},
@@ -67,13 +66,13 @@ TEST_CASE("checks unknown ASCII escapes")
       CHECK(diagnostic.coordinates() == coordinates);
 
       constexpr auto expected_help_message =
-         R"(unrecognised ASCII escape '\5' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
-         "                                                                    ^~"sv;
+u8R"(unrecognised ASCII escape '\5' in string literal `this\nwas\ra\mista\5e\xef`
+                                                                    ^~)"sv;
       CHECK(diagnostic.help_message() == expected_help_message);
    }
 
    SUBCASE("invalid ASCII code") {
-      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('x'));
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape(u8'x'));
       auto const diagnostic = unknown_escape_ascii{
          ill_formed_string,
          {first, ranges::next(first, 4)},
@@ -83,8 +82,8 @@ TEST_CASE("checks unknown ASCII escapes")
       CHECK(diagnostic.coordinates() == coordinates);
 
       constexpr auto expected_help_message =
-         R"(unrecognised ASCII escape '\xef' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
-         "                                                                         ^~~~"sv;
+u8R"(unrecognised ASCII escape '\xef' in string literal `this\nwas\ra\mista\5e\xef`
+                                                                         ^~~~)"sv;
       CHECK(diagnostic.help_message() == expected_help_message);
    }
 }
@@ -93,17 +92,17 @@ TEST_CASE("checks unknown byte escapes") {
    using lingua::unknown_escape_byte;
    using namespace std::string_view_literals;
 
-   constexpr auto ill_formed_string = R"(this\nwas\ra\mista\5e\xef)"sv;
+   constexpr auto ill_formed_string = u8R"(this\nwas\ra\mista\5e\xef)"sv;
    constexpr auto find_unknown_escape = [](auto const escape) constexpr noexcept {
       return [escape](auto const x, auto const y) constexpr noexcept {
-         return x == '\\' and y == escape;
+         return x == u8'\\' and y == escape;
       };
    };
 
    constexpr auto coordinates = lingua_test::make_coordinates(ill_formed_string);
 
    SUBCASE("invalid letter") {
-      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('m'));
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape(u8'm'));
       auto const diagnostic = unknown_escape_byte{
          ill_formed_string,
          {first, ranges::next(first, 2)},
@@ -114,13 +113,13 @@ TEST_CASE("checks unknown byte escapes") {
       CHECK(diagnostic.coordinates() == coordinates);
 
       constexpr auto expected_help_message =
-         R"(unrecognised byte escape '\m' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
-         "                                                             ^~"sv;
+u8R"(unrecognised byte escape '\m' in string literal `this\nwas\ra\mista\5e\xef`
+                                                             ^~)"sv;
       CHECK(diagnostic.help_message() == expected_help_message);
    }
 
    SUBCASE("invalid digit") {
-      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape('5'));
+      auto const first = ranges::adjacent_find(ill_formed_string, find_unknown_escape(u8'5'));
       auto const diagnostic = unknown_escape_byte{
          ill_formed_string,
          {first, ranges::next(first, 2)},
@@ -131,14 +130,14 @@ TEST_CASE("checks unknown byte escapes") {
       CHECK(diagnostic.coordinates() == coordinates);
 
       constexpr auto expected_help_message =
-         R"(unrecognised byte escape '\5' in string literal `this\nwas\ra\mista\5e\xef`)""\n"
-         "                                                                   ^~"sv;
+u8R"(unrecognised byte escape '\5' in string literal `this\nwas\ra\mista\5e\xef`
+                                                                   ^~)"sv;
       CHECK(diagnostic.help_message() == expected_help_message);
    }
 }
 
-void check_diagnostic(std::string_view const ill_formed_string, std::string_view const bad_escape,
-   std::string_view const expected_help_message) noexcept
+void check_diagnostic(std::u8string_view const ill_formed_string, std::u8string_view const bad_escape,
+   std::u8string_view const expected_help_message) noexcept
 {
    auto const coordinates = lingua_test::make_coordinates(ill_formed_string);
    using ranges::begin, ranges::end;
@@ -164,28 +163,28 @@ void check_diagnostic(std::string_view const ill_formed_string, std::string_view
 
 TEST_CASE("checks unknown Unicode escapes") {
    using namespace std::string_view_literals;
-   constexpr auto ill_formed_string = R"(this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d})"sv;
+   constexpr auto ill_formed_string = u8R"(this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d})"sv;
 
    SUBCASE("\\u{5tr1ng}") {
-      constexpr auto bad_escape = "\\u{5tr1ng}"sv;
+      constexpr auto bad_escape = u8"\\u{5tr1ng}"sv;
       constexpr auto expected_help_message =
-         R"(unrecognised Unicode escape '\u{5tr1ng}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
-         "                                                                 ^~~~~~~~~~"sv;
+u8R"(unrecognised Unicode escape '\u{5tr1ng}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`
+                                                                 ^~~~~~~~~~)"sv;
       check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
    }
 
    SUBCASE("\\u{ill}") {
-      constexpr auto bad_escape = "\\u{ill}"sv;
+      constexpr auto bad_escape = u8"\\u{ill}"sv;
       constexpr auto expected_help_message =
-         R"(unrecognised Unicode escape '\u{ill}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
-         "                                                                                       ^~~~~~~"sv;
+u8R"(unrecognised Unicode escape '\u{ill}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`
+                                                                                       ^~~~~~~)"sv;
       check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
    }
    SUBCASE("\\u{f0rM3d}") {
-      constexpr auto bad_escape = "\\u{f0rM3d}"sv;
+      constexpr auto bad_escape = u8"\\u{f0rM3d}"sv;
       constexpr auto expected_help_message =
-         R"(unrecognised Unicode escape '\u{f0rM3d}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`)""\n"
-         "                                                                                                  ^~~~~~~~~~"sv;
+u8R"(unrecognised Unicode escape '\u{f0rM3d}' in string literal `this \u{5tr1ng} \u{69}\u{073} \u{ill}-\u{f0rM3d}`
+                                                                                                  ^~~~~~~~~~)"sv;
       check_diagnostic(ill_formed_string, bad_escape, expected_help_message);
    }
 }

--- a/test/unit/lexer/is_escape.cpp
+++ b/test/unit/lexer/is_escape.cpp
@@ -27,46 +27,66 @@
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/transform.hpp>
 
-#define LINGUA_CHECK_COMMON(IS_VALID_ESCAPE, ESCAPE_MAX) {                                              \
-      CHECK(IS_VALID_ESCAPE(R"(\n)"));                                                                  \
-      CHECK(IS_VALID_ESCAPE(R"(\r)"));                                                                  \
-      CHECK(IS_VALID_ESCAPE(R"(\t)"));                                                                  \
-      CHECK(IS_VALID_ESCAPE(R"(\\)"));                                                                  \
-      CHECK(IS_VALID_ESCAPE(R"(\0)"));                                                                  \
-                                                                                                        \
-      namespace view = ranges::view;                                                                    \
-      for (auto i : view::iota(0, ESCAPE_MAX)) {                                                        \
-         auto const escape = fmt::format(R"(\x{:02x})", i);                                             \
-         CHECK(IS_VALID_ESCAPE(escape));                                                                \
-      }                                                                                                 \
-                                                                                                        \
-      using namespace std::string_view_literals;                                                        \
-      auto not_ascii_escape = [escapes = "nrtx\\0"sv](auto const c) noexcept {                          \
-         return escapes.find(c) == std::string_view::npos;                                              \
-      };                                                                                                \
-      auto non_escapes = view::iota(std::numeric_limits<char>::min(), std::numeric_limits<char>::max()) \
-                       | view::filter(not_ascii_escape);                                                \
-      for (auto const c : non_escapes) {                                                                \
-         auto const non_escape = fmt::format(R"(\{})", c);                                              \
-         CHECK(not IS_VALID_ESCAPE(non_escape));                                                        \
-      }                                                                                                 \
+template<int escape_max, class F>
+void check_is_escape_common(F const& is_escape) noexcept
+{
+   CHECK(is_escape(u8R"(\n)"));
+   CHECK(is_escape(u8R"(\r)"));
+   CHECK(is_escape(u8R"(\t)"));
+   CHECK(is_escape(u8R"(\\)"));
+   CHECK(is_escape(u8R"(\0)"));
+
+   namespace view = ranges::view;
+   for (auto i : view::iota(0, escape_max)) {
+      auto const escape = fmt::format(u8R"(\x{:02x})", i);
+      CHECK(is_escape(escape));
    }
 
-TEST_CASE("checks ASCII escapes are valid")
-{
-   LINGUA_CHECK_COMMON(lingua::is_ascii_escape, 128);
+   using namespace std::string_view_literals;
+   auto not_ascii_escape = [escapes = u8"nrtx\\0"sv](auto const c) noexcept {
+      return escapes.find(c) == std::u8string_view::npos;
+   };
+   auto non_escapes = view::iota(0, std::numeric_limits<char8_t>::max() + 1)
+                    | view::transform([](auto const c) noexcept { return static_cast<char8_t>(c); })
+                    | view::filter(not_ascii_escape)
+                    | view::transform([](auto const c) { return fmt::format(u8R"(\{})", c); });
+   for (auto const non_escape : non_escapes) {
+      for (auto x : non_escape) {
+         fmt::print("{}", static_cast<char>(x));
+      }
+      fmt::print("\n");
+      CHECK(ranges::distance(non_escape) == 2);
+      CHECK(not is_escape(non_escape));
+   }
 }
 
-TEST_CASE("checks byte escapes are valid")
-{
-   LINGUA_CHECK_COMMON(lingua::is_byte_escape, 256);
+TEST_CASE("checks ASCII escapes are valid") {
+   check_is_escape_common<128>(lingua::is_ascii_escape);
 }
 
-#undef LINGUA_CHECK_COMMON
+TEST_CASE("checks byte escapes are valid") {
+   check_is_escape_common<256>(lingua::is_byte_escape);
+}
 
 template<int N>
 class generate_strings {
+   friend class generate_strings<N + 1>;
+   static constexpr long long compute_permutations() noexcept
+   {
+      constexpr auto distance = '~' - ' ';
+      if constexpr (N == 0) {
+         static_assert(N != 0);
+      }
+      else if constexpr (N == 1) {
+         return distance;
+      }
+      else {
+         return distance + generate_strings<N - 1>::compute_permutations();
+      }
+   }
 public:
+   inline static constexpr auto prefixed_permutations = compute_permutations();
+
    auto operator()() const noexcept
    { return impl(); }
 
@@ -76,14 +96,14 @@ private:
    {
       namespace view = ranges::view;
       if constexpr (sizeof...(xs) < N) {
-         auto to_char = [](auto const c) noexcept { return static_cast<char>(c); };
+         auto to_char8_t = [](auto const c) noexcept { return static_cast<char8_t>(c); };
          auto const printable_ascii = view::iota(static_cast<int>(' '), '~' + 1)
-                                    | view::transform(to_char);
+                                    | view::transform(to_char8_t);
          return impl(std::forward<X>(xs)..., printable_ascii);
       }
       else {
          auto make_string = []<class... Ts>(std::tuple<Ts...> const& x) noexcept {
-            return fill_result(std::string(sizeof...(Ts), 'z'), x,
+            return fill_result(std::u8string(sizeof...(Ts), u8'z'), x,
                std::make_index_sequence<sizeof...(Ts)>{});
          };
          return view::cartesian_product(std::forward<X>(xs)...) | view::transform(make_string);
@@ -91,266 +111,268 @@ private:
    }
 
    template<class... Ts, std::size_t... Size>
-   static std::string
-   fill_result(std::string result, std::tuple<Ts...> const& x, std::index_sequence<Size...>) noexcept
+   static std::u8string
+   fill_result(std::u8string result, std::tuple<Ts...> const& x, std::index_sequence<Size...>) noexcept
    {
       (..., (result[Size] = std::get<Size>(x)));
       return result;
    }
 };
 
-#define EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(LENGTH) {                                      \
-   using lingua::is_unicode_escape;                                                       \
-   namespace view = ranges::view;                                                         \
-                                                                                          \
-   auto all_hex = [](std::string_view const x) noexcept {                                 \
-      return ranges::all_of(x, cjdb::isxdigit);                                           \
-   };                                                                                     \
-   auto format = view::transform([](auto&& x) noexcept {                                  \
-      return fmt::format(R"(\u{{{}}})", std::forward<decltype(x)>(x));                    \
-   });                                                                                    \
-   auto no_close_braces = view::filter([](std::string_view const x) noexcept {            \
-      return x.find('}') == std::string_view::npos;                                       \
-   });                                                                                    \
-                                                                                          \
-   auto strings = ::generate_strings<LENGTH>{}() | no_close_braces;                       \
-   SUBCASE("valid escapes") {                                                             \
-      auto expected_escapes = strings | view::filter(all_hex) | format;                   \
-      CHECK(ranges::all_of(expected_escapes, is_unicode_escape));                         \
-   }                                                                                      \
-   SUBCASE("invalid escapes") {                                                           \
-      auto expected_non_escapes = strings | view::filter(std::not_fn(all_hex)) | format;  \
-      CHECK(ranges::none_of(expected_non_escapes, is_unicode_escape));                    \
-   }                                                                                      \
-}                                                                                         \
+template<int N>
+void exhaustive_check_is_unicode_escape() noexcept
+{
+   using lingua::is_unicode_escape;
+   namespace view = ranges::view;
+
+   auto all_hex = [](std::u8string_view const x) noexcept {
+      return ranges::all_of(x, cjdb::isxdigit);
+   };
+   auto format = view::transform([](auto&& x) noexcept {
+      return fmt::format(u8R"(\u{{{}}})", std::forward<decltype(x)>(x));
+   });
+   auto no_close_braces = view::filter([](std::u8string_view const x) noexcept {
+      return x.find(u8'}') == std::u8string_view::npos;
+   });
+
+   auto strings = ::generate_strings<N>{}() | no_close_braces;
+   SUBCASE("valid escapes") {
+      auto expected_escapes = strings | view::filter(all_hex) | format;
+      CHECK(ranges::all_of(expected_escapes, is_unicode_escape));
+   }
+   SUBCASE("invalid escapes") {
+      auto expected_non_escapes = strings | view::filter(std::not_fn(all_hex)) | format;
+      CHECK(ranges::none_of(expected_non_escapes, is_unicode_escape));
+   }
+}
 
 
 TEST_CASE("checks Unicode escapes are valid")
 {
-   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(1);
-   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(2);
-   EXHAUSTIVE_CHECK_IS_UNICODE_ESCAPE(3);
+   exhaustive_check_is_unicode_escape<1>();
+   exhaustive_check_is_unicode_escape<2>();
+   exhaustive_check_is_unicode_escape<3>();
 
    SUBCASE("valid escapes") {
       using lingua::is_unicode_escape;
 
       SUBCASE("four digits") {
-         CHECK(is_unicode_escape("\\u{0000}"));
-         CHECK(is_unicode_escape("\\u{0001}"));
-         CHECK(is_unicode_escape("\\u{0002}"));
-         CHECK(is_unicode_escape("\\u{0003}"));
-         CHECK(is_unicode_escape("\\u{0004}"));
-         CHECK(is_unicode_escape("\\u{0005}"));
-         CHECK(is_unicode_escape("\\u{0006}"));
-         CHECK(is_unicode_escape("\\u{0007}"));
-         CHECK(is_unicode_escape("\\u{0008}"));
-         CHECK(is_unicode_escape("\\u{0009}"));
-         CHECK(is_unicode_escape("\\u{000a}"));
-         CHECK(is_unicode_escape("\\u{000b}"));
-         CHECK(is_unicode_escape("\\u{000c}"));
-         CHECK(is_unicode_escape("\\u{000d}"));
-         CHECK(is_unicode_escape("\\u{000e}"));
-         CHECK(is_unicode_escape("\\u{000f}"));
-         CHECK(is_unicode_escape("\\u{000A}"));
-         CHECK(is_unicode_escape("\\u{000B}"));
-         CHECK(is_unicode_escape("\\u{000C}"));
-         CHECK(is_unicode_escape("\\u{000D}"));
-         CHECK(is_unicode_escape("\\u{000E}"));
-         CHECK(is_unicode_escape("\\u{000F}"));
-         CHECK(is_unicode_escape("\\u{2345}"));
-         CHECK(is_unicode_escape("\\u{00D5}"));
-         CHECK(is_unicode_escape("\\u{eeF1}"));
+         CHECK(is_unicode_escape(u8"\\u{0000}"));
+         CHECK(is_unicode_escape(u8"\\u{0001}"));
+         CHECK(is_unicode_escape(u8"\\u{0002}"));
+         CHECK(is_unicode_escape(u8"\\u{0003}"));
+         CHECK(is_unicode_escape(u8"\\u{0004}"));
+         CHECK(is_unicode_escape(u8"\\u{0005}"));
+         CHECK(is_unicode_escape(u8"\\u{0006}"));
+         CHECK(is_unicode_escape(u8"\\u{0007}"));
+         CHECK(is_unicode_escape(u8"\\u{0008}"));
+         CHECK(is_unicode_escape(u8"\\u{0009}"));
+         CHECK(is_unicode_escape(u8"\\u{000a}"));
+         CHECK(is_unicode_escape(u8"\\u{000b}"));
+         CHECK(is_unicode_escape(u8"\\u{000c}"));
+         CHECK(is_unicode_escape(u8"\\u{000d}"));
+         CHECK(is_unicode_escape(u8"\\u{000e}"));
+         CHECK(is_unicode_escape(u8"\\u{000f}"));
+         CHECK(is_unicode_escape(u8"\\u{000A}"));
+         CHECK(is_unicode_escape(u8"\\u{000B}"));
+         CHECK(is_unicode_escape(u8"\\u{000C}"));
+         CHECK(is_unicode_escape(u8"\\u{000D}"));
+         CHECK(is_unicode_escape(u8"\\u{000E}"));
+         CHECK(is_unicode_escape(u8"\\u{000F}"));
+         CHECK(is_unicode_escape(u8"\\u{2345}"));
+         CHECK(is_unicode_escape(u8"\\u{00D5}"));
+         CHECK(is_unicode_escape(u8"\\u{eeF1}"));
       }
 
       SUBCASE("five digits") {
-         CHECK(is_unicode_escape("\\u{00000}"));
-         CHECK(is_unicode_escape("\\u{00001}"));
-         CHECK(is_unicode_escape("\\u{00002}"));
-         CHECK(is_unicode_escape("\\u{00003}"));
-         CHECK(is_unicode_escape("\\u{00004}"));
-         CHECK(is_unicode_escape("\\u{00005}"));
-         CHECK(is_unicode_escape("\\u{00006}"));
-         CHECK(is_unicode_escape("\\u{00007}"));
-         CHECK(is_unicode_escape("\\u{00008}"));
-         CHECK(is_unicode_escape("\\u{00009}"));
-         CHECK(is_unicode_escape("\\u{0000a}"));
-         CHECK(is_unicode_escape("\\u{0000b}"));
-         CHECK(is_unicode_escape("\\u{0000c}"));
-         CHECK(is_unicode_escape("\\u{0000d}"));
-         CHECK(is_unicode_escape("\\u{0000e}"));
-         CHECK(is_unicode_escape("\\u{0000f}"));
-         CHECK(is_unicode_escape("\\u{0000A}"));
-         CHECK(is_unicode_escape("\\u{0000B}"));
-         CHECK(is_unicode_escape("\\u{0000C}"));
-         CHECK(is_unicode_escape("\\u{0000D}"));
-         CHECK(is_unicode_escape("\\u{0000E}"));
-         CHECK(is_unicode_escape("\\u{0000F}"));
-         CHECK(is_unicode_escape("\\u{12345}"));
-         CHECK(is_unicode_escape("\\u{F00D5}"));
-         CHECK(is_unicode_escape("\\u{BeeF1}"));
+         CHECK(is_unicode_escape(u8"\\u{00000}"));
+         CHECK(is_unicode_escape(u8"\\u{00001}"));
+         CHECK(is_unicode_escape(u8"\\u{00002}"));
+         CHECK(is_unicode_escape(u8"\\u{00003}"));
+         CHECK(is_unicode_escape(u8"\\u{00004}"));
+         CHECK(is_unicode_escape(u8"\\u{00005}"));
+         CHECK(is_unicode_escape(u8"\\u{00006}"));
+         CHECK(is_unicode_escape(u8"\\u{00007}"));
+         CHECK(is_unicode_escape(u8"\\u{00008}"));
+         CHECK(is_unicode_escape(u8"\\u{00009}"));
+         CHECK(is_unicode_escape(u8"\\u{0000a}"));
+         CHECK(is_unicode_escape(u8"\\u{0000b}"));
+         CHECK(is_unicode_escape(u8"\\u{0000c}"));
+         CHECK(is_unicode_escape(u8"\\u{0000d}"));
+         CHECK(is_unicode_escape(u8"\\u{0000e}"));
+         CHECK(is_unicode_escape(u8"\\u{0000f}"));
+         CHECK(is_unicode_escape(u8"\\u{0000A}"));
+         CHECK(is_unicode_escape(u8"\\u{0000B}"));
+         CHECK(is_unicode_escape(u8"\\u{0000C}"));
+         CHECK(is_unicode_escape(u8"\\u{0000D}"));
+         CHECK(is_unicode_escape(u8"\\u{0000E}"));
+         CHECK(is_unicode_escape(u8"\\u{0000F}"));
+         CHECK(is_unicode_escape(u8"\\u{12345}"));
+         CHECK(is_unicode_escape(u8"\\u{F00D5}"));
+         CHECK(is_unicode_escape(u8"\\u{BeeF1}"));
       }
 
       SUBCASE("six digits") {
-         CHECK(is_unicode_escape("\\u{000000}"));
-         CHECK(is_unicode_escape("\\u{000001}"));
-         CHECK(is_unicode_escape("\\u{000002}"));
-         CHECK(is_unicode_escape("\\u{000003}"));
-         CHECK(is_unicode_escape("\\u{000040}"));
-         CHECK(is_unicode_escape("\\u{000005}"));
-         CHECK(is_unicode_escape("\\u{000006}"));
-         CHECK(is_unicode_escape("\\u{000007}"));
-         CHECK(is_unicode_escape("\\u{000008}"));
-         CHECK(is_unicode_escape("\\u{000009}"));
-         CHECK(is_unicode_escape("\\u{00000a}"));
-         CHECK(is_unicode_escape("\\u{00000b}"));
-         CHECK(is_unicode_escape("\\u{00000c}"));
-         CHECK(is_unicode_escape("\\u{00000d}"));
-         CHECK(is_unicode_escape("\\u{00000e}"));
-         CHECK(is_unicode_escape("\\u{00000f}"));
-         CHECK(is_unicode_escape("\\u{00000A}"));
-         CHECK(is_unicode_escape("\\u{00000B}"));
-         CHECK(is_unicode_escape("\\u{00000C}"));
-         CHECK(is_unicode_escape("\\u{00000D}"));
-         CHECK(is_unicode_escape("\\u{00000E}"));
-         CHECK(is_unicode_escape("\\u{00000F}"));
-         CHECK(is_unicode_escape("\\u{123045}"));
-         CHECK(is_unicode_escape("\\u{F000D5}"));
-         CHECK(is_unicode_escape("\\u{BeeF10}"));
+         CHECK(is_unicode_escape(u8"\\u{000000}"));
+         CHECK(is_unicode_escape(u8"\\u{000001}"));
+         CHECK(is_unicode_escape(u8"\\u{000002}"));
+         CHECK(is_unicode_escape(u8"\\u{000003}"));
+         CHECK(is_unicode_escape(u8"\\u{000040}"));
+         CHECK(is_unicode_escape(u8"\\u{000005}"));
+         CHECK(is_unicode_escape(u8"\\u{000006}"));
+         CHECK(is_unicode_escape(u8"\\u{000007}"));
+         CHECK(is_unicode_escape(u8"\\u{000008}"));
+         CHECK(is_unicode_escape(u8"\\u{000009}"));
+         CHECK(is_unicode_escape(u8"\\u{00000a}"));
+         CHECK(is_unicode_escape(u8"\\u{00000b}"));
+         CHECK(is_unicode_escape(u8"\\u{00000c}"));
+         CHECK(is_unicode_escape(u8"\\u{00000d}"));
+         CHECK(is_unicode_escape(u8"\\u{00000e}"));
+         CHECK(is_unicode_escape(u8"\\u{00000f}"));
+         CHECK(is_unicode_escape(u8"\\u{00000A}"));
+         CHECK(is_unicode_escape(u8"\\u{00000B}"));
+         CHECK(is_unicode_escape(u8"\\u{00000C}"));
+         CHECK(is_unicode_escape(u8"\\u{00000D}"));
+         CHECK(is_unicode_escape(u8"\\u{00000E}"));
+         CHECK(is_unicode_escape(u8"\\u{00000F}"));
+         CHECK(is_unicode_escape(u8"\\u{123045}"));
+         CHECK(is_unicode_escape(u8"\\u{F000D5}"));
+         CHECK(is_unicode_escape(u8"\\u{BeeF10}"));
       }
    }
 
    SUBCASE("invalid escapes") {
       using lingua::is_unicode_escape;
       SUBCASE("four digits") {
-         CHECK(not is_unicode_escape("\\u{000G}"));
-         CHECK(not is_unicode_escape("\\u{00H1}"));
-         CHECK(not is_unicode_escape("\\u{0I12}"));
-         CHECK(not is_unicode_escape("\\u{J123}"));
-         CHECK(not is_unicode_escape("\\u{12V4}"));
-         CHECK(not is_unicode_escape("\\u{000L}"));
-         CHECK(not is_unicode_escape("\\u{000M}"));
-         CHECK(not is_unicode_escape("\\u{000N}"));
-         CHECK(not is_unicode_escape("\\u{000O}"));
-         CHECK(not is_unicode_escape("\\u{000P}"));
-         CHECK(not is_unicode_escape("\\u{000Q}"));
-         CHECK(not is_unicode_escape("\\u{000R}"));
-         CHECK(not is_unicode_escape("\\u{000S}"));
-         CHECK(not is_unicode_escape("\\u{000T}"));
-         CHECK(not is_unicode_escape("\\u{000U}"));
-         CHECK(not is_unicode_escape("\\u{000V}"));
-         CHECK(not is_unicode_escape("\\u{000W}"));
-         CHECK(not is_unicode_escape("\\u{000X}"));
-         CHECK(not is_unicode_escape("\\u{addY}"));
-         CHECK(not is_unicode_escape("\\u{000Z}"));
-         CHECK(not is_unicode_escape("\\u{000g}"));
-         CHECK(not is_unicode_escape("\\u{00h1}"));
-         CHECK(not is_unicode_escape("\\u{0i12}"));
-         CHECK(not is_unicode_escape("\\u{j123}"));
-         CHECK(not is_unicode_escape("\\u{&234}"));
-         CHECK(not is_unicode_escape("\\u{000l}"));
-         CHECK(not is_unicode_escape("\\u{000m}"));
-         CHECK(not is_unicode_escape("\\u{000n}"));
-         CHECK(not is_unicode_escape("\\u{000o}"));
-         CHECK(not is_unicode_escape("\\u{000p}"));
-         CHECK(not is_unicode_escape("\\u{000q}"));
-         CHECK(not is_unicode_escape("\\u{000r}"));
-         CHECK(not is_unicode_escape("\\u{000s}"));
-         CHECK(not is_unicode_escape("\\u{000t}"));
-         CHECK(not is_unicode_escape("\\u{000u}"));
-         CHECK(not is_unicode_escape("\\u{000v}"));
-         CHECK(not is_unicode_escape("\\u{000w}"));
-         CHECK(not is_unicode_escape("\\u{000x}"));
-         CHECK(not is_unicode_escape("\\u{addy}"));
-         CHECK(not is_unicode_escape("\\u{000z}"));
-         CHECK(not is_unicode_escape("\\u{<>#^}"));
+         CHECK(not is_unicode_escape(u8"\\u{000G}"));
+         CHECK(not is_unicode_escape(u8"\\u{00H1}"));
+         CHECK(not is_unicode_escape(u8"\\u{0I12}"));
+         CHECK(not is_unicode_escape(u8"\\u{J123}"));
+         CHECK(not is_unicode_escape(u8"\\u{12V4}"));
+         CHECK(not is_unicode_escape(u8"\\u{000L}"));
+         CHECK(not is_unicode_escape(u8"\\u{000M}"));
+         CHECK(not is_unicode_escape(u8"\\u{000N}"));
+         CHECK(not is_unicode_escape(u8"\\u{000O}"));
+         CHECK(not is_unicode_escape(u8"\\u{000P}"));
+         CHECK(not is_unicode_escape(u8"\\u{000Q}"));
+         CHECK(not is_unicode_escape(u8"\\u{000R}"));
+         CHECK(not is_unicode_escape(u8"\\u{000S}"));
+         CHECK(not is_unicode_escape(u8"\\u{000T}"));
+         CHECK(not is_unicode_escape(u8"\\u{000U}"));
+         CHECK(not is_unicode_escape(u8"\\u{000V}"));
+         CHECK(not is_unicode_escape(u8"\\u{000W}"));
+         CHECK(not is_unicode_escape(u8"\\u{000X}"));
+         CHECK(not is_unicode_escape(u8"\\u{addY}"));
+         CHECK(not is_unicode_escape(u8"\\u{000Z}"));
+         CHECK(not is_unicode_escape(u8"\\u{000g}"));
+         CHECK(not is_unicode_escape(u8"\\u{00h1}"));
+         CHECK(not is_unicode_escape(u8"\\u{0i12}"));
+         CHECK(not is_unicode_escape(u8"\\u{j123}"));
+         CHECK(not is_unicode_escape(u8"\\u{&234}"));
+         CHECK(not is_unicode_escape(u8"\\u{000l}"));
+         CHECK(not is_unicode_escape(u8"\\u{000m}"));
+         CHECK(not is_unicode_escape(u8"\\u{000n}"));
+         CHECK(not is_unicode_escape(u8"\\u{000o}"));
+         CHECK(not is_unicode_escape(u8"\\u{000p}"));
+         CHECK(not is_unicode_escape(u8"\\u{000q}"));
+         CHECK(not is_unicode_escape(u8"\\u{000r}"));
+         CHECK(not is_unicode_escape(u8"\\u{000s}"));
+         CHECK(not is_unicode_escape(u8"\\u{000t}"));
+         CHECK(not is_unicode_escape(u8"\\u{000u}"));
+         CHECK(not is_unicode_escape(u8"\\u{000v}"));
+         CHECK(not is_unicode_escape(u8"\\u{000w}"));
+         CHECK(not is_unicode_escape(u8"\\u{000x}"));
+         CHECK(not is_unicode_escape(u8"\\u{addy}"));
+         CHECK(not is_unicode_escape(u8"\\u{000z}"));
+         CHECK(not is_unicode_escape(u8"\\u{<>#^}"));
       }
 
       SUBCASE("five digits") {
-         CHECK(not is_unicode_escape("\\u{0000G}"));
-         CHECK(not is_unicode_escape("\\u{000H1}"));
-         CHECK(not is_unicode_escape("\\u{00I12}"));
-         CHECK(not is_unicode_escape("\\u{0J123}"));
-         CHECK(not is_unicode_escape("\\u{K1234}"));
-         CHECK(not is_unicode_escape("\\u{0000L}"));
-         CHECK(not is_unicode_escape("\\u{0000M}"));
-         CHECK(not is_unicode_escape("\\u{0000N}"));
-         CHECK(not is_unicode_escape("\\u{0000O}"));
-         CHECK(not is_unicode_escape("\\u{0000P}"));
-         CHECK(not is_unicode_escape("\\u{0000Q}"));
-         CHECK(not is_unicode_escape("\\u{0000R}"));
-         CHECK(not is_unicode_escape("\\u{0000S}"));
-         CHECK(not is_unicode_escape("\\u{0000T}"));
-         CHECK(not is_unicode_escape("\\u{0000U}"));
-         CHECK(not is_unicode_escape("\\u{0000V}"));
-         CHECK(not is_unicode_escape("\\u{0000W}"));
-         CHECK(not is_unicode_escape("\\u{0000X}"));
-         CHECK(not is_unicode_escape("\\u{baddY}"));
-         CHECK(not is_unicode_escape("\\u{0000Z}"));
-         CHECK(not is_unicode_escape("\\u{0000g}"));
-         CHECK(not is_unicode_escape("\\u{000h1}"));
-         CHECK(not is_unicode_escape("\\u{00i12}"));
-         CHECK(not is_unicode_escape("\\u{0j123}"));
-         CHECK(not is_unicode_escape("\\u{k1&34}"));
-         CHECK(not is_unicode_escape("\\u{0000l}"));
-         CHECK(not is_unicode_escape("\\u{0000m}"));
-         CHECK(not is_unicode_escape("\\u{0000n}"));
-         CHECK(not is_unicode_escape("\\u{0000o}"));
-         CHECK(not is_unicode_escape("\\u{0000p}"));
-         CHECK(not is_unicode_escape("\\u{0000q}"));
-         CHECK(not is_unicode_escape("\\u{0000r}"));
-         CHECK(not is_unicode_escape("\\u{0000s}"));
-         CHECK(not is_unicode_escape("\\u{0000t}"));
-         CHECK(not is_unicode_escape("\\u{0000u}"));
-         CHECK(not is_unicode_escape("\\u{0000v}"));
-         CHECK(not is_unicode_escape("\\u{0000w}"));
-         CHECK(not is_unicode_escape("\\u{0000x}"));
-         CHECK(not is_unicode_escape("\\u{baddy}"));
-         CHECK(not is_unicode_escape("\\u{0000z}"));
-         CHECK(not is_unicode_escape("\\u{$<>#^}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000G}"));
+         CHECK(not is_unicode_escape(u8"\\u{000H1}"));
+         CHECK(not is_unicode_escape(u8"\\u{00I12}"));
+         CHECK(not is_unicode_escape(u8"\\u{0J123}"));
+         CHECK(not is_unicode_escape(u8"\\u{K1234}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000L}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000M}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000N}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000O}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000P}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000Q}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000R}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000S}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000T}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000U}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000V}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000W}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000X}"));
+         CHECK(not is_unicode_escape(u8"\\u{baddY}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000Z}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000g}"));
+         CHECK(not is_unicode_escape(u8"\\u{000h1}"));
+         CHECK(not is_unicode_escape(u8"\\u{00i12}"));
+         CHECK(not is_unicode_escape(u8"\\u{0j123}"));
+         CHECK(not is_unicode_escape(u8"\\u{k1&34}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000l}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000m}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000n}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000o}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000p}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000q}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000r}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000s}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000t}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000u}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000v}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000w}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000x}"));
+         CHECK(not is_unicode_escape(u8"\\u{baddy}"));
+         CHECK(not is_unicode_escape(u8"\\u{0000z}"));
+         CHECK(not is_unicode_escape(u8"\\u{$<>#^}"));
       }
 
       SUBCASE("six digits") {
-         CHECK(not is_unicode_escape("\\u{00a00G}"));
-         CHECK(not is_unicode_escape("\\u{00a0H1}"));
-         CHECK(not is_unicode_escape("\\u{00aI12}"));
-         CHECK(not is_unicode_escape("\\u{0Ja123}"));
-         CHECK(not is_unicode_escape("\\u{K1a234}"));
-         CHECK(not is_unicode_escape("\\u{00a00L}"));
-         CHECK(not is_unicode_escape("\\u{00a00M}"));
-         CHECK(not is_unicode_escape("\\u{00a00N}"));
-         CHECK(not is_unicode_escape("\\u{00a00O}"));
-         CHECK(not is_unicode_escape("\\u{00a00P}"));
-         CHECK(not is_unicode_escape("\\u{00a00Q}"));
-         CHECK(not is_unicode_escape("\\u{00a00R}"));
-         CHECK(not is_unicode_escape("\\u{00a00S}"));
-         CHECK(not is_unicode_escape("\\u{00a00T}"));
-         CHECK(not is_unicode_escape("\\u{00a00U}"));
-         CHECK(not is_unicode_escape("\\u{00a00V}"));
-         CHECK(not is_unicode_escape("\\u{00a00W}"));
-         CHECK(not is_unicode_escape("\\u{00a00X}"));
-         CHECK(not is_unicode_escape("\\u{baaddY}"));
-         CHECK(not is_unicode_escape("\\u{00a00Z}"));
-         CHECK(not is_unicode_escape("\\u{00a00g}"));
-         CHECK(not is_unicode_escape("\\u{00a0h1}"));
-         CHECK(not is_unicode_escape("\\u{00ai12}"));
-         CHECK(not is_unicode_escape("\\u{0ja123}"));
-         CHECK(not is_unicode_escape("\\u{k1a2&4}"));
-         CHECK(not is_unicode_escape("\\u{00a00l}"));
-         CHECK(not is_unicode_escape("\\u{00a00m}"));
-         CHECK(not is_unicode_escape("\\u{00a00n}"));
-         CHECK(not is_unicode_escape("\\u{00a00o}"));
-         CHECK(not is_unicode_escape("\\u{00a00p}"));
-         CHECK(not is_unicode_escape("\\u{00a00q}"));
-         CHECK(not is_unicode_escape("\\u{00a00r}"));
-         CHECK(not is_unicode_escape("\\u{00a00s}"));
-         CHECK(not is_unicode_escape("\\u{00a00t}"));
-         CHECK(not is_unicode_escape("\\u{00a00u}"));
-         CHECK(not is_unicode_escape("\\u{00a00v}"));
-         CHECK(not is_unicode_escape("\\u{00a00w}"));
-         CHECK(not is_unicode_escape("\\u{00a00x}"));
-         CHECK(not is_unicode_escape("\\u{baaddy}"));
-         CHECK(not is_unicode_escape("\\u{00a00z}"));
-         CHECK(not is_unicode_escape("\\u{$<a>#^}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00G}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a0H1}"));
+         CHECK(not is_unicode_escape(u8"\\u{00aI12}"));
+         CHECK(not is_unicode_escape(u8"\\u{0Ja123}"));
+         CHECK(not is_unicode_escape(u8"\\u{K1a234}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00L}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00M}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00N}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00O}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00P}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00Q}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00R}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00S}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00T}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00U}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00V}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00W}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00X}"));
+         CHECK(not is_unicode_escape(u8"\\u{baaddY}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00Z}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00g}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a0h1}"));
+         CHECK(not is_unicode_escape(u8"\\u{00ai12}"));
+         CHECK(not is_unicode_escape(u8"\\u{0ja123}"));
+         CHECK(not is_unicode_escape(u8"\\u{k1a2&4}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00l}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00m}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00n}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00o}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00p}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00q}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00r}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00s}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00t}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00u}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00v}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00w}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00x}"));
+         CHECK(not is_unicode_escape(u8"\\u{baaddy}"));
+         CHECK(not is_unicode_escape(u8"\\u{00a00z}"));
+         CHECK(not is_unicode_escape(u8"\\u{$<a>#^}"));
       }
    }
 }

--- a/test/unit/source_coordinate.cpp
+++ b/test/unit/source_coordinate.cpp
@@ -243,14 +243,14 @@ TEST_CASE("checks source_coordinate is implemented correctly") {
    SUBCASE("Check ostream operators are correct") {
       SUBCASE("Check line") {
          constexpr auto line = source_coordinate::line_type{32};
-         auto const result = fmt::format("{}", line);
-         CHECK(result == "32");
+         auto const result = fmt::format(u8"{}", line);
+         CHECK(result == u8"32");
       }
 
       SUBCASE("Check column") {
          constexpr auto column = source_coordinate::column_type{28};
-         auto const result = fmt::format("{}", column);
-         CHECK(result == "28");
+         auto const result = fmt::format(u8"{}", column);
+         CHECK(result == u8"28");
       }
 
       SUBCASE("Check source_coordinate") {
@@ -259,8 +259,8 @@ TEST_CASE("checks source_coordinate is implemented correctly") {
             source_coordinate::column_type{4}
          };
 
-         auto const result = fmt::format("{}", cursor);
-         CHECK(result == "10:4");
+         auto const result = fmt::format(u8"{}", cursor);
+         CHECK(result == u8"10:4");
       }
    }
 }

--- a/test/unit/source_coordinate_range.cpp
+++ b/test/unit/source_coordinate_range.cpp
@@ -18,14 +18,15 @@
 #include "lingua/source_coordinate.hpp"
 #include <doctest.h>
 
-TEST_CASE("checks that source_coordinate_ranges behave correctly")
-{
+TEST_CASE("checks that source_coordinate_ranges behave correctly") {
    using lingua::source_coordinate;
    using lingua::source_coordinate_range;
 
    constexpr auto first1 = source_coordinate{};
-   constexpr auto last1 =
-      source_coordinate{source_coordinate::line_type{15}, source_coordinate::column_type{7}};
+   constexpr auto last1 = source_coordinate{
+      source_coordinate::line_type{15},
+      source_coordinate::column_type{7}
+   };
    constexpr auto r1 = source_coordinate_range{first1, last1};
 
    CHECK(r1.begin() == first1);
@@ -35,8 +36,10 @@ TEST_CASE("checks that source_coordinate_ranges behave correctly")
    CHECK(not(r1 != r1));
 
    // check an empty range
-   constexpr auto first2 =
-      source_coordinate{source_coordinate::line_type{4}, source_coordinate::column_type{18}};
+   constexpr auto first2 = source_coordinate{
+      source_coordinate::line_type{4},
+      source_coordinate::column_type{18}
+   };
    constexpr auto r2 = source_coordinate_range{first2, first2};
    CHECK(r2.begin() == first2);
    CHECK(r2.end() == first2);


### PR DESCRIPTION
Rust's lexicon is UTF-8, not ASCII, so the character set has been
updated accordingly (now that there's compiler support).