### PR TITLE
adds unknown token diagnostic (closes #8)

### DIFF
--- a/include/lingua/diagnostic/lexical/unknown_token.hpp
+++ b/include/lingua/diagnostic/lexical/unknown_token.hpp
@@ -1,0 +1,49 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEXICAL_UNKNOWN_TOKEN_HPP
+#define LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEXICAL_UNKNOWN_TOKEN_HPP
+
+#include "lingua/diagnostic/detail/diagnostic_base.hpp"
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/utility/contract.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include <fmt/format.h>
+#include <range/v3/algorithm/none_of.hpp>
+#include <string_view>
+
+namespace lingua {
+   class unknown_token : private detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed> {
+      using base_t = detail_diagnostic::diagnostic_base<diagnostic_level::ill_formed>;
+   public:
+      using base_t::coordinates;
+      using base_t::help_message;
+      using base_t::level;
+
+      explicit unknown_token(std::u8string_view const lexeme,
+         source_coordinate_range const coordinates) noexcept
+         : base_t{coordinates, fmt::format(u8R"(unknown token "{}")", lexeme)}
+      { LINGUA_EXPECTS(not_valid_token(lexeme)); }
+   private:
+      static bool not_valid_token(std::u8string_view const lexeme) noexcept
+      {
+         return ranges::none_of(lexeme, [](auto const c) noexcept {
+            return u8' ' < c and c < u8'~' and c != u8'`' and c != u8'\\';
+         });
+      }
+   };
+} // namespace lingua
+
+#endif // LINGUA_DIAGNOSTIC_DIAGNOSTIC_LEXICAL_UNKNOWN_TOKEN_HPP

--- a/test/unit/diagnostic/lexical/CMakeLists.txt
+++ b/test/unit/diagnostic/lexical/CMakeLists.txt
@@ -35,3 +35,14 @@ lingua_add_test(
       doctest::doctest
       fmt::fmt
       range-v3)
+
+lingua_add_test(
+   FILENAME unknown_token.cpp
+   INCLUDE "${CMAKE_SOURCE_DIR}/test/include"
+   COMPILER_DEFINITIONS
+      DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+   LIBRARIES
+      cjdb
+      doctest::doctest
+      fmt::fmt
+      range-v3)

--- a/test/unit/diagnostic/lexical/unknown_token.cpp
+++ b/test/unit/diagnostic/lexical/unknown_token.cpp
@@ -1,0 +1,42 @@
+//
+//  Copyright 2019 Christopher Di Bella
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "lingua/diagnostic/lexical/unknown_token.hpp"
+
+#include "lingua/diagnostic/diagnostic_level.hpp"
+#include "lingua/source_coordinate_range.hpp"
+#include "lingua_test/make_coordinates.hpp"
+#include <doctest.h>
+#include <fmt/format.h>
+
+void check_unknown_token(std::u8string_view const token)
+{
+   auto const coordinates = lingua_test::make_coordinates(token);
+   auto const diagnostic = lingua::unknown_token{token, coordinates};
+   CHECK(diagnostic.level == lingua::diagnostic_level::ill_formed);
+   CHECK(diagnostic.coordinates() == coordinates);
+
+   auto const expected_message = fmt::format(u8R"(unknown token "{}")", token);
+   CHECK(diagnostic.help_message() == expected_message);
+}
+
+TEST_CASE("checks the error type for unknown tokens") {
+   using lingua::unknown_token;
+   using namespace std::string_view_literals;
+
+   check_unknown_token(u8"`");
+   check_unknown_token(u8"~");
+   check_unknown_token(u8"££");
+}


### PR DESCRIPTION
Rust has strict rules about which characters can and cannot form tokens,
and how they're allowed to form tokens (e.g. a character represented by
UTF-8 falling outside the Latin alphabet can be used in a string, but it
can't be used in an identifier).

This commit adds a diagnostic that can identify unknown tokens.